### PR TITLE
Add scoped AGENTS guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,37 @@
+# .github agent instructions
+
+## Purpose
+
+`.github/` 管理 GitHub Actions：基础测试、MySQL/SQLite smoke、多平台 PyInstaller 构建和 Release 资产发布。
+
+## Scope
+
+适用于 `.github/workflows/` 下的所有 workflow。
+
+## Read first
+
+- `.github/workflows/test.yml`
+- `.github/workflows/multi-platform-build.yaml`
+- 根目录 `AGENTS.md` 的验证和安全规则。
+
+## Local rules
+
+- `test.yml` 是仓库当前最完整的行为验证来源：Python 3.11、依赖安装、`unittest`、CSV/Excel 到 SQLite/MySQL smoke。
+- 数据库相关代码变化时，不要移除 MySQL 8.0 服务或 SQLite/MySQL smoke，除非提供等价覆盖。
+- `multi-platform-build.yaml` 分别构建 XDB 主程序和 3 个 XLSX 辅助工具，并用 artifact 名称驱动后续平台包和 Release 包；重命名 artifact 时必须更新所有下载、打包和上传步骤。
+- Release zip 期望按 `linux-x64`、`linux-arm64`、`windows-x64`、`macos-arm64` 输出，并包含 XDB 与 3 个 XLSX 工具。
+- 当前版本号来自提交标题 `git log --format=%B -1 | head -1`；修改版本策略会影响 artifact 和 Release 名称。
+
+## Do not
+
+- 不在 workflow 日志中打印非测试密钥、真实数据库连接串或用户数据。
+- 不把构建产物提交到仓库；artifact 和 release asset 由 Actions 生成。
+- 不随意扩大 `contents: write` 权限范围；只在发布任务需要时保留。
+
+## Validation
+
+无法从仓库中确认专用本地 workflow 校验命令，优先运行根目录通用验证命令：`python -m unittest discover -s tests -p 'test_*.py'`。涉及 PyInstaller 命令时，对照 workflow 中的实际 install/build 命令检查依赖和入口文件名。
+
+## Notes for future agents
+
+这里的改动风险主要是 CI 覆盖下降和 release 资产命名断链；提交前用 diff 顺序检查 build、download、bundle、publish 四段是否仍匹配。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# XDB agent instructions
+
+## Purpose
+
+本仓库是 Python CLI 工具，核心入口是 `XDB.py`，用于将 Excel/CSV 转换到 SQLite 或 MySQL，并提供字段映射、表名映射、分块并行处理和类型推断。
+
+## Scope
+
+本文件适用于整个仓库。进入 `scripts/`、`tests/`、`.github/` 时还要读取对应子目录的 `AGENTS.md`。
+
+## Read first
+
+- `README.md`：用户可见的 CLI 行为、参数和映射格式。
+- `requirements.txt`：运行依赖来源。
+- `XDB.py`：主程序、数据库抽象、映射、SQL 安全和 CLI 参数。
+- `tests/test_xdb_regressions.py`：当前回归覆盖点。
+- `.github/workflows/test.yml`：CI 中的回归测试和 MySQL/SQLite smoke。
+
+## Local rules
+
+- 保持 `XDB.py` 作为单文件 CLI 的现有边界；拆分模块前必须同步更新入口、测试和打包流程。
+- 修改 CLI 参数、默认值、字段映射格式、表名映射格式或输出行为时，同步更新 README 和回归测试。
+- SQL 表名/列名必须经过现有 `validate_sql_identifier`、`safe_sql_identifier`、`sanitize_table_name`、`sanitize_column_name` 等路径处理；不要把外部输入直接拼进 SQL。
+- 保持表名优先级：`--table-mapping` 高于 `--target-table`，再回退到工作表名。
+- 字段映射必须保留源列顺序和目标列类型对应关系；涉及 mapping、chunk、CSV/Excel 兼容性时优先补回归测试。
+- `overwrite` 会删除并重建目标表。验证时使用临时 SQLite 文件或明确的测试 MySQL 库，不要指向用户现有数据库。
+
+## Do not
+
+- 不手动修改 `dist/`、`build/`、`__pycache__/`、coverage、PyInstaller `*.spec` 等生成或缓存产物。
+- 不引入新的 package manager、格式化器、lint/typecheck 工具，除非同时提交配置和验证说明。
+- 不提交非测试用途的数据库密码、token 或用户数据样本；CI 里已有的 `testpass` 仅用于测试服务。
+
+## Validation
+
+- 安装依赖：`python -m pip install -r requirements.txt`
+- 通用回归：`python -m unittest discover -s tests -p 'test_*.py'`
+- CLI smoke：用临时 CSV/XLSX 运行 `python XDB.py <input.csv> --db-type sqlite --sqlite-path <tmp.db> --target-table <table> --mode overwrite --quiet`
+- 涉及 MySQL 写入时，参考 `.github/workflows/test.yml` 的 MySQL 8.0 服务和连接参数补充验证。
+
+## Notes for future agents
+
+仓库没有 `pyproject.toml`、`Makefile`、`Dockerfile` 或本地 lint/typecheck 配置；不要编造这些命令。当前测试框架是标准库 `unittest`。

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,43 @@
+# scripts agent instructions
+
+## Purpose
+
+`scripts/` 保存独立的 Excel 辅助工具：拆分 CSV、按 sheet 切割、合并 sheet，以及客户名称分类。它们服务于数据整理，不是 `XDB.py` 的核心导入路径。
+
+## Scope
+
+适用于 `scripts/` 下的 Python 脚本、`config_template.ini` 和脚本文档。
+
+## Read first
+
+- `scripts/README_XLSX-split.md`
+- `scripts/config_template.ini`
+- 修改目标脚本本身的 CLI 参数、输入列和输出文件逻辑。
+- `.github/workflows/multi-platform-build.yaml` 中对应 PyInstaller 构建命令。
+
+## Local rules
+
+- 保持脚本可从仓库根目录直接运行；修改参数时同步脚本文档或用法提示。
+- `XLSX-split.py` 依赖 INI 的 `General`、`TagDepartments`、`ColumnMappings`，可选 `DELLIST`；不要破坏这些 key 名称的兼容性。
+- `XLSX-SheetCutter.py` 和 `XLSX-SheetMerger.py` 当前只复制单元格值，不复制样式；如果改变语义，要在用法说明中写清楚。
+- `客户分类切割.py` 依赖输入表的 `Name` 列，分类规则顺序会影响结果；修改关键词或顺序时用样例数据验证。
+- 输出的 CSV/XLSX 是用户数据产物；测试时写入临时目录。
+
+## Do not
+
+- 不把本机真实绝对路径写进脚本默认值；示例路径只放在模板或文档中。
+- 不手动提交脚本生成的 CSV/XLSX 输出文件。
+- 不让辅助脚本反向依赖 `XDB.py` 的内部实现，除非同时补测试说明和打包验证。
+
+## Validation
+
+无法从仓库中确认专用自动测试命令，优先运行根目录通用验证命令。按改动脚本补最小 smoke：
+
+- `python scripts/XLSX-split.py -c <config.ini>`
+- `python scripts/XLSX-SheetCutter.py <input.xlsx>`
+- `python scripts/XLSX-SheetMerger.py <input1.xlsx> <input2.xlsx>`
+- `python scripts/客户分类切割.py <input.xlsx> <output_dir>`
+
+## Notes for future agents
+
+CI 会用 PyInstaller 分别打包 `XLSX-split.py`、`XLSX-SheetCutter.py`、`XLSX-SheetMerger.py`；重命名文件或入口会影响 release 资产。

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,37 @@
+# tests agent instructions
+
+## Purpose
+
+`tests/` 保存 XDB 的回归测试，重点覆盖字段映射、列顺序、类型推断、SQL 标识符清理和数据库写入行为。
+
+## Scope
+
+适用于 `tests/` 下的所有测试文件和测试 fixture。
+
+## Read first
+
+- `tests/test_xdb_regressions.py`
+- `XDB.py` 中被测函数或类。
+- `.github/workflows/test.yml` 的 CI 测试步骤。
+
+## Local rules
+
+- 使用标准库 `unittest` 风格，保持 `python -m unittest discover -s tests -p 'test_*.py'` 可发现。
+- 需要调用 CLI 时使用 `sys.executable` 和仓库根目录的 `XDB.py`，避免依赖 shell alias 或当前目录偶然状态。
+- 测试文件、SQLite 数据库和输出结果必须放在 `tempfile.TemporaryDirectory()` 或等价临时位置。
+- 单元级 MySQL 行为优先用 fake connection/cursor；需要真实 MySQL 时对齐 CI 的测试服务参数。
+- 修复 mapping、chunk、append/overwrite、SQL 安全或 CSV/Excel 解析问题时，添加能失败再通过的回归测试。
+
+## Do not
+
+- 不让测试依赖执行顺序、用户本机数据库、固定绝对路径或仓库外部样本文件。
+- 不在测试中写入持久 `.db`、`.xlsx`、`.csv` 或日志文件到仓库根目录。
+- 不吞掉子进程 stderr/stdout；CLI 失败时要能看见诊断信息。
+
+## Validation
+
+- `python -m unittest discover -s tests -p 'test_*.py'`
+
+## Notes for future agents
+
+当前测试目录在 CI 中先于完整 CSV/Excel/MySQL smoke 执行；这里适合放快速、可本地运行的回归用例。


### PR DESCRIPTION
## Summary
- Add root-level Codex/agent guidance for the XDB Python CLI repository.
- Add scoped instructions for scripts, tests, and GitHub Actions workflows.
- Document real validation commands and repository-specific risk areas without changing runtime code.

## Validation
- `python -m unittest discover -s tests -p "test_*.py"`
- `git diff --cached --check` before commit

## Notes
- This PR intentionally contains only `AGENTS.md` files.
- Existing local non-AGENTS changes were left out of the commit.