### PR TITLE
Fix import regressions and scoped agent guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,37 +1,32 @@
-# .github agent instructions
+# .github navigation card
 
-## Purpose
+`.github/` 管理 CI、MySQL/SQLite smoke、多平台 PyInstaller 构建和 Release 发布。
+任何 workflow、artifact 名称或权限改动前先读本卡片。
+关键文件：`.github/workflows/test.yml`、`.github/workflows/multi-platform-build.yaml`。
 
-`.github/` 管理 GitHub Actions：基础测试、MySQL/SQLite smoke、多平台 PyInstaller 构建和 Release 资产发布。
+## Why this is high-risk
 
-## Scope
+- `test.yml` 是最完整行为 gate：Python 3.11、依赖安装、`unittest`、CSV/Excel 到 SQLite/MySQL。
+- `multi-platform-build.yaml` 把入口文件、hidden imports、artifact 名称、平台包和 release upload 串在一起。
+- Release 发布使用 `contents: write`；权限变化会影响仓库发布权。
 
-适用于 `.github/workflows/` 下的所有 workflow。
+## Required before changes
 
-## Read first
-
-- `.github/workflows/test.yml`
-- `.github/workflows/multi-platform-build.yaml`
-- 根目录 `AGENTS.md` 的验证和安全规则。
-
-## Local rules
-
-- `test.yml` 是仓库当前最完整的行为验证来源：Python 3.11、依赖安装、`unittest`、CSV/Excel 到 SQLite/MySQL smoke。
-- 数据库相关代码变化时，不要移除 MySQL 8.0 服务或 SQLite/MySQL smoke，除非提供等价覆盖。
-- `multi-platform-build.yaml` 分别构建 XDB 主程序和 3 个 XLSX 辅助工具，并用 artifact 名称驱动后续平台包和 Release 包；重命名 artifact 时必须更新所有下载、打包和上传步骤。
-- Release zip 期望按 `linux-x64`、`linux-arm64`、`windows-x64`、`macos-arm64` 输出，并包含 XDB 与 3 个 XLSX 工具。
-- 当前版本号来自提交标题 `git log --format=%B -1 | head -1`；修改版本策略会影响 artifact 和 Release 名称。
+- 读取被改 workflow，追踪被重命名 job、artifact、path、platform 或 output variable 的下游消费者。
+- 数据库行为改动必须保留或等价替换 SQLite 与 MySQL smoke。
+- 打包改动要核对 install、PyInstaller、upload-artifact、download-artifact pattern、bundle layout、release upload。
+- 保持平台集合有意为之：`linux-x64`、`linux-arm64`、`windows-x64`、`macos-arm64`。
+- 当前版本号来自最新提交标题：`git log --format=%B -1 | head -1`。
 
 ## Do not
 
-- 不在 workflow 日志中打印非测试密钥、真实数据库连接串或用户数据。
-- 不把构建产物提交到仓库；artifact 和 release asset 由 Actions 生成。
-- 不随意扩大 `contents: write` 权限范围；只在发布任务需要时保留。
+- 不移除 `test.yml` 的 MySQL 8.0 service，除非提供等价 MySQL 验证。
+- 不提交构建产物；artifact 和 release asset 由 Actions 生成。
+- 不把 `contents: write` 扩大到非发布 job，除非 workflow 确实需要。
+- 不在 workflow 日志打印非测试 secrets、真实数据库 URL 或用户数据。
 
 ## Validation
 
-无法从仓库中确认专用本地 workflow 校验命令，优先运行根目录通用验证命令：`python -m unittest discover -s tests -p 'test_*.py'`。涉及 PyInstaller 命令时，对照 workflow 中的实际 install/build 命令检查依赖和入口文件名。
-
-## Notes for future agents
-
-这里的改动风险主要是 CI 覆盖下降和 release 资产命名断链；提交前用 diff 顺序检查 build、download、bundle、publish 四段是否仍匹配。
+- 默认本地检查：`python -m unittest discover -s tests -p 'test_*.py'`。
+- 仅 workflow 改动时逐段检查 diff；不假设本地能执行 GitHub Actions。
+- PyInstaller 命令需要 workflow 依赖安装步骤和平台构建环境。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
     - name: 安装依赖
       run: pip install pandas openpyxl pymysql tqdm psutil chardet cryptography
 
+    - name: 运行回归测试
+      run: python -m unittest discover -s tests -p 'test_*.py'
+
     - name: 创建测试数据
       run: |
         # 创建CSV测试文件

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 config.ini
 .DS_Store
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,99 @@
-# XDB agent instructions
+# XDB repository agent instructions
 
 ## Purpose
 
-本仓库是 Python CLI 工具，核心入口是 `XDB.py`，用于将 Excel/CSV 转换到 SQLite 或 MySQL，并提供字段映射、表名映射、分块并行处理和类型推断。
+本仓库是 Python CLI 工具仓库。核心入口是 `XDB.py`，用于把 Excel/CSV 导入 SQLite 或 MySQL，并提供字段映射、表名映射、分块处理、并行处理、类型推断、CSV 参数处理和数据库写入验证。
 
-## Scope
+## Codex startup behavior
 
-本文件适用于整个仓库。进入 `scripts/`、`tests/`、`.github/` 时还要读取对应子目录的 `AGENTS.md`。
+- Codex 通常从仓库根目录 `/Users/sky/GitHub/XDB` 启动；本文件是启动期主规则。
+- 子目录 `AGENTS.md` 是按需 navigation card；从根目录启动时不会天然进入上下文，必须按本文件的目录地图主动读取。
+- 修改 `scripts/`、`tests/`、`.github/` 下文件前，先读取对应目录的 `AGENTS.md`。
+- 如果从子目录启动，Codex 也可能自动加载路径链上的本地 `AGENTS.md`；仍以本文件的目录地图作为根启动 workflow 的 router。
+- 如果新增目录需要独立职责边界、专属验证或高风险保护，只创建必要的 `AGENTS.md`；不要为了覆盖率给纯组织目录建空卡片。
 
-## Read first
+## Directory map
 
-- `README.md`：用户可见的 CLI 行为、参数和映射格式。
-- `requirements.txt`：运行依赖来源。
-- `XDB.py`：主程序、数据库抽象、映射、SQL 安全和 CLI 参数。
-- `tests/test_xdb_regressions.py`：当前回归覆盖点。
-- `.github/workflows/test.yml`：CI 中的回归测试和 MySQL/SQLite smoke。
+| Path | Responsibility | Local AGENTS.md | Read when |
+|---|---|---:|---|
+| `XDB.py` | 主 CLI、数据库抽象、Excel/CSV 解析、映射、类型推断、SQL 安全和写入流程 | No | 修改导入行为、CLI 参数、数据库写入、字段/表名映射、chunk/并行处理、CSV/Excel 兼容性前 |
+| `README.md` | 用户可见说明、参数语义、示例和映射格式 | No | 修改 CLI 参数、默认值、输出行为、映射语法或用户可见兼容性前 |
+| `requirements.txt` | 运行依赖来源 | No | 新增、删除或升级 Python 依赖前 |
+| `tests/` | 标准库 `unittest` 回归测试 | Yes | 新增或修改测试、fixture、CLI 子进程调用、数据库 fake/smoke 前 |
+| `scripts/` | 独立 Excel 辅助工具和脚本文档，不是 `XDB.py` 核心导入路径 | Yes | 修改 `XLSX-split.py`、sheet cutter/merger、客户分类脚本、脚本配置或脚本文档前 |
+| `.github/` | GitHub Actions 测试、MySQL/SQLite smoke、多平台 PyInstaller 构建和 Release 资产发布 | Yes | 修改 workflow、artifact 名称、release 权限、Python 版本、MySQL 服务或 CI 验证步骤前 |
+| `.codex/` | 本地 Codex 相关元数据，当前不在 `git ls-files` 跟踪清单内 | No | 仅用户明确要求维护本地 Codex 配置时读取；不要把它当作仓库产品代码 |
+| `.claude/` | 本地 Claude/agent 相关元数据，当前不在 `git ls-files` 跟踪清单内 | No | 仅用户明确要求维护本地 agent 配置时读取 |
+| `__pycache__/`, `dist/`, `build/`, coverage 输出 | 缓存、构建或测试产物 | No | 不手动编辑；需要验证时删除/重建也必须先确认是否属于当前任务 |
 
-## Local rules
+## On-demand cat protocol
 
-- 保持 `XDB.py` 作为单文件 CLI 的现有边界；拆分模块前必须同步更新入口、测试和打包流程。
-- 修改 CLI 参数、默认值、字段映射格式、表名映射格式或输出行为时，同步更新 README 和回归测试。
-- SQL 表名/列名必须经过现有 `validate_sql_identifier`、`safe_sql_identifier`、`sanitize_table_name`、`sanitize_column_name` 等路径处理；不要把外部输入直接拼进 SQL。
-- 保持表名优先级：`--table-mapping` 高于 `--target-table`，再回退到工作表名。
-- 字段映射必须保留源列顺序和目标列类型对应关系；涉及 mapping、chunk、CSV/Excel 兼容性时优先补回归测试。
-- `overwrite` 会删除并重建目标表。验证时使用临时 SQLite 文件或明确的测试 MySQL 库，不要指向用户现有数据库。
+修改带有本地 `AGENTS.md` 的目录前，先读取对应文件：
+
+```bash
+cat <path>/AGENTS.md
+```
+
+如果目标路径上未来出现多层嵌套 `AGENTS.md`，按从浅到深的顺序读取后再修改。如果目标目录存在 `AGENTS.override.md`，先暂停并询问用户维护 override 还是调整策略；不要写入会被同目录 override 屏蔽的普通 `AGENTS.md`。
+
+## Commands
+
+| Command | Purpose | Scope | Sandbox notes |
+|---|---|---|---|
+| `python -m pip install -r requirements.txt` | 安装仓库运行依赖 | repo | 依赖未缓存时需要网络 |
+| `python -m unittest discover -s tests -p 'test_*.py'` | 运行本地回归测试 | repo/tests | 默认本地验证；不需要外部数据库 |
+| `python XDB.py <input.csv> --db-type sqlite --sqlite-path <tmp.db> --target-table <table> --mode overwrite --quiet` | 最小 CSV-to-SQLite CLI smoke | `XDB.py` | 只使用临时输入和临时 SQLite 文件 |
+| `python XDB.py <input.xlsx> --db-type sqlite --sqlite-path <tmp.db> --target-table <table> --mode overwrite --quiet` | 最小 Excel-to-SQLite CLI smoke | `XDB.py` | 只使用临时 workbook 和临时 SQLite 文件 |
+| `python XDB.py <input.csv> --db-type mysql --mysql-host 127.0.0.1 --mysql-user root --mysql-password testpass --mysql-database testdb --target-table <table> --mode overwrite` | CI 风格 CSV-to-MySQL smoke | `XDB.py` | 需要 MySQL 8.0 测试服务；不要指向用户数据 |
+| `python scripts/XLSX-split.py -c <config.ini>` | 验证 `XLSX-split.py` 显式配置路径 | `scripts/` | config 中使用临时输入/输出路径 |
+| `python scripts/XLSX-SheetCutter.py <input.xlsx>` | 验证 sheet cutter | `scripts/` | 使用临时 workbook |
+| `python scripts/XLSX-SheetMerger.py <input1.xlsx> <input2.xlsx>` | 验证 sheet merger | `scripts/` | 使用临时 workbook |
+| `python scripts/客户分类切割.py <input.xlsx> <output_dir>` | 验证客户分类切割脚本 | `scripts/` | 使用临时 workbook 和临时输出目录 |
+| `pyinstaller --onefile --hidden-import=pandas,openpyxl,pymysql,tqdm,psutil,chardet,concurrent.futures,multiprocessing --strip XDB.py --distpath dist/<platform>` | CI 中的 XDB 二进制构建命令 | `.github/workflows/multi-platform-build.yaml` | 需要 PyInstaller 和平台构建环境；输出是生成产物 |
+| `pyinstaller --onefile --hidden-import=csv,os,codecs,configparser,argparse,openpyxl --strip scripts/XLSX-split.py --distpath dist/<platform>` | CI 中的 `XLSX-split` 构建命令 | `.github/workflows/multi-platform-build.yaml` | 需要 PyInstaller；输出是生成产物 |
+
+仓库没有 `pyproject.toml`、`Makefile`、`Dockerfile`、本地 lint 配置、本地 typecheck 配置或自定义 package manager 命令。不要编造 `make`、`pytest`、`ruff`、`mypy`、`poetry`、`uv`、`npm` 或 Docker 命令，除非仓库之后真实新增对应配置。
+
+## Global rules
+
+- 保持 `XDB.py` 作为单文件 CLI 边界。拆分模块必须同步更新入口路径、测试、打包 workflow、README 和 CLI smoke 说明。
+- README 可见行为属于用户契约。修改 CLI flags、默认值、mapping 语法、表名行为、输出行为或用户依赖的错误信息时，同步更新 `README.md` 和回归测试。
+- 保持表名优先级：`--table-mapping` 高于 `--target-table`，再高于源 sheet 名或 CSV fallback。
+- 保持字段映射顺序和类型对齐。mapping 变更必须让源列顺序与目标列类型在 SQLite/MySQL 写入中保持一致。
+- SQL 表名和列名必须经过 `validate_sql_identifier`、`safe_sql_identifier`、`sanitize_table_name`、`sanitize_column_name` 等现有路径；不要把未校验外部输入拼进 SQL。
+- `overwrite` 会 drop 并重建目标表；本地验证必须使用临时 SQLite 文件或明确的可丢弃 MySQL 数据库。
+- `append` 必须保留既有表语义；修改 append 时验证目标列匹配、缺列行为、行数、commit/rollback。
+- CSV 处理必须保留显式 `--csv-encoding`、`--csv-separator`、`--csv-quotechar`、`--csv-no-header` 行为；不要用字符串切割替代结构化 CSV 解析。
+- Excel 处理必须继续覆盖 sheet 选择、merged cells、header 提取和大文件 chunk；除非明确验证，不要无意增加内存占用。
+- 并行/chunk 变更要检查测试依赖的行顺序、chunk 边界丢失/重复、异常传播和 rollback 安全。
+- MySQL 行为优先用 fake connection/cursor 做单元验证；真实 MySQL 验证按 CI service 设置执行，服务不可用时可标注跳过。
+- 生成文件、构建输出、缓存目录和用户数据输出不是 source of truth；应修改源脚本、workflow 或测试 fixture。
 
 ## Do not
 
-- 不手动修改 `dist/`、`build/`、`__pycache__/`、coverage、PyInstaller `*.spec` 等生成或缓存产物。
-- 不引入新的 package manager、格式化器、lint/typecheck 工具，除非同时提交配置和验证说明。
-- 不提交非测试用途的数据库密码、token 或用户数据样本；CI 里已有的 `testpass` 仅用于测试服务。
+- 不把 `dist/`、`build/`、`__pycache__/`、coverage 输出、PyInstaller `*.spec`、release bundle 或临时 CSV/XLSX/SQLite 输出当作源码修改。
+- 不把验证指向用户真实 SQLite 数据库、MySQL schema、生产 host 或不可丢弃的 spreadsheet。
+- 不引入新的 package manager、formatter、linter、typechecker、test runner 或 build system，除非同时提交配置并说明验证路径。
+- 不移除 CI 的 MySQL 或 SQLite smoke 覆盖，除非同一改动提供等价检查。
+- 不在日志或提交文件里打印非测试凭据、真实数据库连接串或用户数据样本；CI 的 `testpass` 仅限测试服务。
+- 不重命名 CLI 入口、workflow artifact 或 release asset 路径，除非追踪 `.github/workflows/` 中所有消费者。
+- 不在窄 bugfix 中混入大范围重构；行为改动要绑定可复现问题和回归测试。
 
 ## Validation
 
-- 安装依赖：`python -m pip install -r requirements.txt`
-- 通用回归：`python -m unittest discover -s tests -p 'test_*.py'`
-- CLI smoke：用临时 CSV/XLSX 运行 `python XDB.py <input.csv> --db-type sqlite --sqlite-path <tmp.db> --target-table <table> --mode overwrite --quiet`
-- 涉及 MySQL 写入时，参考 `.github/workflows/test.yml` 的 MySQL 8.0 服务和连接参数补充验证。
+默认本地环境下，代码修改完成后：
+
+1. 运行 `python -m unittest discover -s tests -p 'test_*.py'`。
+2. 如果改动涉及 CLI parsing、CSV/Excel 输入、数据库写入或 mapping 行为，用临时文件运行 SQLite smoke：`python XDB.py ... --db-type sqlite ... --mode overwrite --quiet`。
+3. 如果改动涉及 MySQL SQL、连接、commit/rollback 或 CI MySQL smoke，补 fake-connection 单元测试，或在可丢弃 MySQL 8.0 测试服务上运行 CI 风格命令。
+4. 如果改动涉及 `scripts/`，用临时输入/输出运行 Commands 表中的对应脚本 smoke。
+5. 如果改动涉及 `.github/workflows/`，按 install → build/test → artifact download → bundle → publish 检查 diff；不假设本地能完整执行 GitHub Actions。
+
+仅修改 `AGENTS.md` 时，不需要运行数据导入测试，除非需要额外信心；改为确认只改了 `AGENTS.md` 文件，且目录地图仍指向正确的本地卡片。
 
 ## Notes for future agents
 
-仓库没有 `pyproject.toml`、`Makefile`、`Dockerfile` 或本地 lint/typecheck 配置；不要编造这些命令。当前测试框架是标准库 `unittest`。
+- 这个仓库里 edge case 正确性比 happy path 导入速度更重要。高价值回归点包括 sample-based primary-key inference、merged cells、raw header mapping、已有 `id` 列、显式 `--csv-quotechar`、field mapping order 和 chunk rollback。
+- 当前测试框架是标准库 `unittest`。保持 `python -m unittest discover -s tests -p 'test_*.py'` 可发现。
+- 最快的安全 review 路径：先看 `XDB.py` 中被改行为；共享行为补 `tests/test_xdb_regressions.py`；用户可见导入路径再做临时 SQLite CLI smoke。
+- 工作树可能已有非 `AGENTS.md` 修改。除非用户明确要求，不要 revert。

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ XDB采用模块化设计，主要包含以下核心组件：
 4. **类型检测与映射**：
    - 基于样本数据智能推断类型
    - 针对不同数据库定制类型映射策略
-   - 主键自动检测和优化
+   - 默认创建独立自增主键，避免样本误判导致导入失败
 
 5. **字段映射引擎**：
    - 多种映射配置方式（文件、内联）
@@ -258,9 +258,13 @@ flowchart LR
 pandas>=1.0.0
 openpyxl>=3.0.0
 tqdm>=4.45.0
-pymysql>=1.0.0 (MySQL支持)
+pymysql>=1.0.0
 psutil>=5.7.0
+chardet>=5.0.0
+xlsxwriter>=3.0.0
 ```
+
+其中 `pymysql` 用于 MySQL 导入，`xlsxwriter` 用于 `scripts/客户分类切割.py` 辅助脚本。
 
 ### 安装方法
 
@@ -425,6 +429,8 @@ python XDB.py large_file.xlsx --db-type sqlite --sqlite-path output.db \
 ```
 "工作表1:Excel列1=数据库列1,Excel列2=数据库列2;工作表2:Excel列3=数据库列3"
 ```
+
+源字段可以使用 Excel/CSV 中看到的原始表头，也可以使用程序清理后的安全列名；目标字段会被清理成安全数据库列名。
 
 例如：
 ```

--- a/XDB.py
+++ b/XDB.py
@@ -198,13 +198,13 @@ def normalize_transform_rules(sheet_rules, raw_headers, headers):
 
 def generated_pk_name(headers):
     """选择不会和源字段冲突的自动主键列名"""
-    existing = set(headers or [])
+    existing = {str(header).casefold() for header in (headers or [])}
     for candidate in ('id', 'xdb_id', '_xdb_id'):
-        if candidate not in existing:
+        if candidate.casefold() not in existing:
             return candidate
 
     counter = 1
-    while f'_xdb_id_{counter}' in existing:
+    while f'_xdb_id_{counter}'.casefold() in existing:
         counter += 1
     return f'_xdb_id_{counter}'
 

--- a/XDB.py
+++ b/XDB.py
@@ -39,8 +39,12 @@ import psutil
 from datetime import datetime
 from openpyxl import load_workbook
 import getpass
-import pymysql
-from pymysql.cursors import DictCursor
+try:
+    import pymysql
+    from pymysql.cursors import DictCursor
+except ImportError:
+    pymysql = None
+    DictCursor = None
 from contextlib import contextmanager
 from abc import ABC, abstractmethod
 import csv
@@ -52,34 +56,31 @@ def validate_sql_identifier(name):
     """验证SQL标识符安全性（表名、列名等）"""
     if not name or not isinstance(name, str):
         raise ValueError("SQL标识符不能为空")
-    
+
     # 移除首尾空格
     name = name.strip()
-    
+
     # 长度限制
     if len(name) > 64:
         raise ValueError(f"SQL标识符过长（最大64字符）: {name}")
-    
+
     # 只允许字母、数字、下划线、中文
     import re
     if not re.match(r'^[a-zA-Z_\u4e00-\u9fff][a-zA-Z0-9_\u4e00-\u9fff]*$', name):
         raise ValueError(f"SQL标识符包含非法字符: {name}")
-    
-    # SQL关键字和危险字符黑名单
-    dangerous_patterns = [
-        # SQL关键字
+
+    # SQL关键字黑名单只做完整匹配。字符级危险内容已由上面的白名单拦截；
+    # 使用子串匹配会把 created_at、updated_at、delete_flag 等正常字段误改成 hash 名。
+    reserved_keywords = {
         'DROP', 'DELETE', 'UPDATE', 'INSERT', 'SELECT', 'ALTER', 'CREATE', 'TRUNCATE',
         'UNION', 'EXEC', 'EXECUTE', 'DECLARE', 'CAST', 'CONVERT', 'MERGE',
-        # 危险字符和模式
-        ';', '--', '/*', '*/', 'XP_', 'SP_', 'OPENROWSET', 'OPENQUERY',
-        'BULK', 'LOAD_FILE', 'INTO OUTFILE', 'INTO DUMPFILE'
-    ]
-    
+        'OPENROWSET', 'OPENQUERY', 'BULK', 'LOAD_FILE'
+    }
+
     name_upper = name.upper()
-    for pattern in dangerous_patterns:
-        if pattern in name_upper:
-            raise ValueError(f"SQL标识符包含危险关键字或字符: {name}")
-    
+    if name_upper in reserved_keywords:
+        raise ValueError(f"SQL标识符使用保留关键字: {name}")
+
     return name
 
 def safe_sql_identifier(name):
@@ -93,7 +94,7 @@ def sanitize_table_name(raw_name):
     """清理表名，确保SQL安全"""
     if not raw_name:
         return 'default_table'
-    
+
     try:
         # 先用现有的clean_table_name清理
         cleaned = clean_table_name(raw_name)
@@ -109,7 +110,7 @@ def sanitize_column_name(raw_name):
     """清理列名，确保SQL安全"""
     if not raw_name:
         return 'default_column'
-    
+
     try:
         # 基础清理
         cleaned = str(raw_name).strip()
@@ -120,7 +121,7 @@ def sanitize_column_name(raw_name):
         # 确保以字母开头
         if not cleaned or not (cleaned[0].isalpha() or '\u4e00' <= cleaned[0] <= '\u9fff'):
             cleaned = 'col_' + cleaned
-        
+
         # SQL安全验证
         return safe_sql_identifier(cleaned[:64])
     except ValueError as e:
@@ -129,38 +130,130 @@ def sanitize_column_name(raw_name):
         safe_hash = hashlib.md5(str(raw_name).encode()).hexdigest()[:8]
         return f"col_{safe_hash}"
 
+def build_header_aliases(raw_headers, sanitized_headers):
+    """建立用户可见表头到内部安全表头的映射"""
+    aliases = {}
+    raw_headers = raw_headers or []
+
+    for i, sanitized in enumerate(sanitized_headers):
+        candidates = {str(sanitized).strip(), f"Column_{i+1}"}
+        raw = raw_headers[i] if i < len(raw_headers) else None
+        if raw is not None and str(raw).strip() != '':
+            candidates.add(str(raw).strip())
+            try:
+                candidates.add(sanitize_column_name(str(raw)))
+            except ValueError:
+                pass
+
+        for candidate in candidates:
+            if candidate and candidate not in aliases:
+                aliases[candidate] = sanitized
+
+    return aliases
+
+def normalize_field_mapping(sheet_mapping, raw_headers, headers):
+    """把字段映射中的源/目标列名规范化为内部安全列名"""
+    logger = logging.getLogger(__name__)
+    aliases = build_header_aliases(raw_headers, headers)
+    normalized = {}
+    used_target_columns = set()
+
+    for excel_col, db_col in sheet_mapping.items():
+        source_key = str(excel_col).strip()
+        source_header = aliases.get(source_key)
+
+        if not source_header:
+            logger.warning(f"映射字段 '{excel_col}' 在源文件中不存在，将跳过")
+            continue
+
+        if not db_col or str(db_col).strip() == '':
+            logger.warning(f"映射字段 '{excel_col}' 的目标列名为空，将跳过")
+            continue
+
+        target_header = sanitize_column_name(str(db_col))
+        if target_header in used_target_columns:
+            logger.warning(f"目标列名 '{target_header}' 重复，将跳过后续重复映射")
+            continue
+
+        normalized[source_header] = target_header
+        used_target_columns.add(target_header)
+
+    return normalized
+
+def normalize_transform_rules(sheet_rules, raw_headers, headers):
+    """把转换规则中的列名规范化为内部安全列名"""
+    logger = logging.getLogger(__name__)
+    aliases = build_header_aliases(raw_headers, headers)
+    normalized = {}
+
+    for column_name, rule in sheet_rules.items():
+        source_key = str(column_name).strip()
+        source_header = aliases.get(source_key)
+        if not source_header:
+            logger.warning(f"转换字段 '{column_name}' 在源文件中不存在，将跳过")
+            continue
+        normalized[source_header] = rule
+
+    return normalized
+
+def generated_pk_name(headers):
+    """选择不会和源字段冲突的自动主键列名"""
+    existing = set(headers or [])
+    for candidate in ('id', 'xdb_id', '_xdb_id'):
+        if candidate not in existing:
+            return candidate
+
+    counter = 1
+    while f'_xdb_id_{counter}' in existing:
+        counter += 1
+    return f'_xdb_id_{counter}'
+
+def build_mapping_plan(headers, field_mapping):
+    """按源文件列顺序生成字段映射计划，供建表、类型检测、写入复用"""
+    if not field_mapping:
+        return []
+    return [
+        (i, header, field_mapping[header])
+        for i, header in enumerate(headers)
+        if header in field_mapping
+    ]
+
+def mapped_headers_in_source_order(headers, field_mapping):
+    """获取按源文件列顺序排列的目标字段名"""
+    return [target_header for _, _, target_header in build_mapping_plan(headers, field_mapping)]
+
 def validate_safe_path(file_path):
     """验证文件路径是否安全，防止路径遍历攻击"""
     if not file_path:
         raise ValueError("文件路径不能为空")
-    
+
     # 获取绝对路径并规范化
     abs_path = os.path.abspath(file_path)
-    
+
     # 检查危险模式
     dangerous_patterns = ['..', '~', '$']
     for pattern in dangerous_patterns:
         if pattern in file_path:
             raise ValueError(f"文件路径包含危险字符: {pattern}")
-    
+
     # 检查是否尝试访问系统关键目录
     forbidden_paths = [
         '/etc', '/bin', '/sbin', '/usr/bin', '/usr/sbin',
         '/System', '/Library', '/Applications',
         'C:\\Windows', 'C:\\Program Files', 'C:\\System32'
     ]
-    
+
     for forbidden in forbidden_paths:
         if abs_path.startswith(forbidden):
             raise ValueError(f"不允许访问系统目录: {forbidden}")
-    
+
     # 确保路径在当前工作目录或子目录中（可选的额外安全检查）
     current_dir = os.getcwd()
     if not abs_path.startswith(current_dir) and not os.path.isabs(file_path):
         # 对于相对路径，确保解析后在安全范围内
         if '..' in os.path.normpath(file_path):
             raise ValueError("不允许使用相对路径遍历到父目录")
-    
+
     return abs_path
 
 # 工具函数
@@ -184,38 +277,38 @@ def setup_logger(level=logging.INFO, log_file=None):
     """配置日志系统"""
     logger = logging.getLogger()
     logger.setLevel(level)
-    
+
     # 清除已有处理器
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
-    
+
     # 创建格式化器
     formatter = logging.Formatter(
         '%(asctime)s - %(levelname)s - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
-    
+
     # 添加控制台处理器
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
-    
+
     # 添加文件处理器(如果指定)
     if log_file:
         file_handler = logging.FileHandler(log_file, encoding='utf-8')
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-    
+
     return logger
 
 # 检测文件类型
 def detect_file_type(file_path):
     """检测文件类型（Excel或CSV）"""
     logger = logging.getLogger(__name__)
-    
+
     _, ext = os.path.splitext(file_path)
     ext = ext.lower()
-    
+
     if ext in ['.xlsx', '.xls']:
         return 'excel'
     elif ext == '.csv':
@@ -225,18 +318,18 @@ def detect_file_type(file_path):
         try:
             with open(file_path, 'rb') as f:
                 sample = f.read(4096)  # 读取前4KB
-                
+
             # 检测是否有逗号或分号等常见CSV分隔符
             text_sample = sample.decode('utf-8', errors='ignore')
             comma_count = text_sample.count(',')
             semicolon_count = text_sample.count(';')
             tab_count = text_sample.count('\t')
-            
+
             # 判断是否可能是CSV
             if comma_count > 5 or semicolon_count > 5 or tab_count > 5:
                 logger.info(f"文件 {file_path} 看起来像是CSV格式，将作为CSV处理")
                 return 'csv'
-                
+
             logger.warning(f"无法识别 {file_path} 的文件类型，将尝试作为Excel处理")
             return 'excel'
         except Exception as e:
@@ -247,19 +340,19 @@ def detect_file_type(file_path):
 def detect_csv_properties(csv_path, sample_size=4096):
     """检测CSV文件的编码和分隔符"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 读取文件样本用于检测
         with open(csv_path, 'rb') as f:
             sample = f.read(sample_size)
-        
+
         # 检测编码（改进版，防御性编程）
         result = chardet.detect(sample)
-        
+
         # 防御性处理：chardet可能返回None或异常结果
         if not result or not isinstance(result, dict):
             result = {'encoding': None, 'confidence': 0.0}
-        
+
         if result.get('confidence', 0) > 0.8 and result.get('encoding'):
             encoding = result['encoding']
         elif result.get('confidence', 0) > 0.5 and result.get('encoding') in ['utf-8', 'gbk', 'gb2312', 'gb18030', 'utf-16']:
@@ -274,15 +367,15 @@ def detect_csv_properties(csv_path, sample_size=4096):
                     break
                 except UnicodeDecodeError:
                     continue
-            
+
             if not encoding:
                 encoding = 'utf-8'  # 最后的安全网
-        
+
         logger.info(f"检测到编码: {encoding} (置信度: {result.get('confidence', 0):.2f})")
-        
+
         # 使用检测到的编码读取文件样本（防御性编程）
         text_sample = sample.decode(encoding or 'utf-8', errors='ignore')
-        
+
         # 计算可能的分隔符
         sep_candidates = {
             ',': text_sample.count(','),
@@ -290,32 +383,39 @@ def detect_csv_properties(csv_path, sample_size=4096):
             '\t': text_sample.count('\t'),
             '|': text_sample.count('|')
         }
-        
+
         # 确定最有可能的分隔符
         if any(sep_candidates.values()):
             max_sep = max(sep_candidates, key=sep_candidates.get)
         else:
             max_sep = ','  # 默认使用逗号分隔符
-        
+
         # 检查是否有引号字符
         double_quote_count = text_sample.count('"')
         single_quote_count = text_sample.count("'")
         quotechar = '"' if double_quote_count > single_quote_count else "'"
-        
+
         logger.info(f"CSV检测结果 - 编码: {encoding}, 分隔符: {repr(max_sep)}, 引号字符: {quotechar}")
-        
+
         # 尝试检测是否有表头
         lines = text_sample.split('\n')
         has_header = True
         if len(lines) >= 2:
-            # 检查第一行和第二行的分隔符计数是否一致
-            header_sep_count = lines[0].count(max_sep)
-            data_sep_count = lines[1].count(max_sep)
-            
-            if header_sep_count != data_sep_count:
+            try:
+                parsed_rows = list(csv.reader(
+                    [line for line in lines[:5] if line.strip()],
+                    delimiter=max_sep,
+                    quotechar=quotechar,
+                    doublequote=True,
+                    skipinitialspace=True
+                ))
+                if len(parsed_rows) >= 2 and len(parsed_rows[0]) != len(parsed_rows[1]):
+                    has_header = False
+                    logger.warning("CSV文件可能没有表头，将使用默认列名")
+            except csv.Error:
                 has_header = False
                 logger.warning("CSV文件可能没有表头，将使用默认列名")
-        
+
         return {
             'encoding': encoding,
             'sep': max_sep,
@@ -336,7 +436,7 @@ def clean_table_name(name):
     """清理表名，确保符合数据库命名规范"""
     if not name:
         return 'T_default'
-    
+
     # 移除特殊字符，保留中文、英文、数字、下划线
     cleaned = re.sub(r'[^\w\u4e00-\u9fff]', '_', name)
     # 移除连续的下划线
@@ -396,7 +496,7 @@ def is_date_value(value):
     """检测值是否为日期（支持多种格式）"""
     if isinstance(value, datetime):
         return True
-    
+
     if isinstance(value, str):
         value = value.strip()
         # 支持多种日期格式
@@ -411,44 +511,36 @@ def is_date_value(value):
             r'^\d{1,2}-\w{3}-\d{4}$',                      # 01-Jan-2023
             r'^\w{3} \d{1,2}, \d{4}$',                     # Jan 01, 2023
         ]
-        
+
         for pattern in date_patterns:
             if re.match(pattern, value):
                 return True
-    
+
     return False
 
 def detect_column_types(sample_data, headers, db_type='sqlite'):
     """分析样本数据，检测每列的数据类型，根据目标数据库类型返回适当的类型定义"""
     logger = logging.getLogger(__name__)
-    
+
     if not sample_data or not headers:
         return ['TEXT'] * len(headers) if db_type == 'sqlite' else ['VARCHAR(255)'] * len(headers)
-    
+
     detected_types = []
-    
-    # 检查第一列是否可以作为主键（值唯一）
-    first_col_values = [
-        row[0] for row in sample_data 
-        if row and len(row) > 0 and row[0] is not None
-    ]
-    is_potential_pk = (len(first_col_values) == len(set(first_col_values)) 
-                       and len(first_col_values) > 0)
-    
+
     # 转置样本数据，按列分析（边界条件保护）
     valid_rows = [row for row in sample_data if row]
     if not valid_rows:
         # 如果没有有效数据，返回默认类型
         return ['TEXT'] * len(headers) if db_type == 'sqlite' else ['VARCHAR(255)'] * len(headers)
-    
+
     max_cols = max(len(row) for row in valid_rows)
     columns = [[] for _ in range(max_cols)]
-    
+
     for row in sample_data:
         for i, val in enumerate(row):
             if i < max_cols and val is not None:
                 columns[i].append(val)
-    
+
     for i, column_data in enumerate(columns):
         try:
             # 移除空值
@@ -460,20 +552,20 @@ def detect_column_types(sample_data, headers, db_type='sqlite'):
                 # 优化的类型检测 - 单次遍历检测所有类型
                 type_counters = {
                     'integer': 0,
-                    'float': 0, 
+                    'float': 0,
                     'date': 0,
                     'boolean': 0,
                     'long_text': 0
                 }
                 max_str_length = 0
                 total_values = len(non_empty)
-                
+
                 # 单次遍历，检测所有类型
                 for x in non_empty:
                     str_x = str(x)
                     str_len = len(str_x)
                     max_str_length = max(max_str_length, str_len)
-                    
+
                     # 检测类型（优化顺序：从最严格到最宽松）
                     if is_integer_value(x):
                         type_counters['integer'] += 1
@@ -483,18 +575,15 @@ def detect_column_types(sample_data, headers, db_type='sqlite'):
                         type_counters['date'] += 1
                     elif str_x.lower() in ('true', 'false', '0', '1', 'yes', 'no'):
                         type_counters['boolean'] += 1
-                    
+
                     if isinstance(x, str) and str_len > 255:
                         type_counters['long_text'] += 1
-                
+
                 # 根据统计结果确定最佳类型（95%一致性阈值）
                 threshold = max(1, int(total_values * 0.95))
-                
+
                 if type_counters['integer'] >= threshold:
-                    if db_type == 'sqlite':
-                        column_type = ('INTEGER PRIMARY KEY' if i == 0 and is_potential_pk else 'INTEGER')
-                    else:  # MySQL
-                        column_type = ('INT AUTO_INCREMENT PRIMARY KEY' if i == 0 and is_potential_pk else 'INT')
+                    column_type = 'INTEGER' if db_type == 'sqlite' else 'INT'
                 elif type_counters['float'] >= threshold:
                     column_type = 'REAL' if db_type == 'sqlite' else 'DOUBLE'
                 elif type_counters['date'] >= threshold:
@@ -507,30 +596,30 @@ def detect_column_types(sample_data, headers, db_type='sqlite'):
                     # 优化的VARCHAR长度计算
                     safe_length = min(max(max_str_length + 50, 100), 255)
                     column_type = 'TEXT' if db_type == 'sqlite' else f'VARCHAR({safe_length})'
-                
+
             detected_types.append(column_type)
         except Exception as e:
             logger.warning(f"列 '{headers[i] if i < len(headers) else i}' 类型检测失败: {str(e)}，使用默认文本类型")
             column_type = 'TEXT' if db_type == 'sqlite' else 'VARCHAR(255)'
             detected_types.append(column_type)
-    
+
     # 补齐类型（如果样本数据列数不足）
     while len(detected_types) < len(headers):
         column_type = 'TEXT' if db_type == 'sqlite' else 'VARCHAR(255)'
         detected_types.append(column_type)
-    
+
     return detected_types
 
 # Excel读取与处理
 def get_excel_info(excel_path, sheet_name=None):
     """获取Excel文件的基本信息"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 获取所有工作表 - 优化资源管理
         with pd.ExcelFile(excel_path) as xls:
             sheet_names = xls.sheet_names
-        
+
         if sheet_name is not None and sheet_name not in sheet_names:
             if isinstance(sheet_name, int) and 0 <= sheet_name < len(sheet_names):
                 sheet_name = sheet_names[sheet_name]
@@ -539,21 +628,21 @@ def get_excel_info(excel_path, sheet_name=None):
                 sheet_name = sheet_names[0]
         elif sheet_name is None:
             sheet_name = sheet_names[0]
-        
+
         # 使用openpyxl获取工作表信息，避免加载全部数据
         wb = None
         try:
             wb = load_workbook(excel_path, read_only=True)
             ws = wb[sheet_name] if sheet_name in wb.sheetnames else wb.active
-            
+
             # 检查工作表是否有效
             if ws is None:
                 raise ValueError(f"无法获取工作表: {sheet_name}")
-            
+
             # 获取表头行
             header_row = next(ws.rows)
             header = [cell.value for cell in header_row]
-            
+
             # 清理表头（SQL安全版）
             cleaned_header = []
             for i, col in enumerate(header):
@@ -562,7 +651,7 @@ def get_excel_info(excel_path, sheet_name=None):
                 else:
                     # 使用安全的列名清理
                     col = sanitize_column_name(str(col))
-                
+
                 # 确保唯一性
                 base_col = col
                 counter = 1
@@ -570,7 +659,7 @@ def get_excel_info(excel_path, sheet_name=None):
                     col = f"{base_col}_{counter}"
                     counter += 1
                 cleaned_header.append(col)
-            
+
             # 估计行数
             try:
                 estimated_rows = ws.max_row - 1
@@ -589,7 +678,7 @@ def get_excel_info(excel_path, sheet_name=None):
                     wb.close()
                 except Exception as e:
                     logger.warning(f"关闭Excel工作簿失败: {e}")
-        
+
         return {
             'sheet_names': sheet_names,
             'current_sheet': sheet_name,
@@ -604,51 +693,27 @@ def get_excel_info(excel_path, sheet_name=None):
 def get_csv_info(csv_path, csv_props=None):
     """获取CSV文件的基本信息"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 如果未提供CSV属性，则进行检测
         if csv_props is None:
             csv_props = detect_csv_properties(csv_path)
-        
+
         encoding = csv_props['encoding']
         sep = csv_props['sep']
         quotechar = csv_props['quotechar']
         has_header = csv_props['has_header']
-        
+
         # 获取表头和行数估计
         with open(csv_path, 'r', encoding=encoding, errors='replace') as f:
-            # 读取前几行用于表头检测
-            sample_lines = []
-            for _ in range(5):  # 读取前5行
-                line = f.readline()
-                if not line:
-                    break
-                sample_lines.append(line)
-            
-            # 使用csv模块解析第一行获取字段数
-            sniffer = csv.Sniffer()
-            dialect = csv.excel
-            try:
-                # 尝试检测CSV方言
-                if sample_lines:
-                    dialect = sniffer.sniff('\n'.join(sample_lines), delimiters=',;\t|')
-            except (csv.Error, ValueError):
-                # 使用检测到的分隔符创建自定义方言
-                class CustomDialect(csv.Dialect):
-                    delimiter = sep
-                    quotechar = csv_props['quotechar']  # 直接从字典获取
-                    doublequote = True
-                    skipinitialspace = True
-                    lineterminator = '\r\n'
-                    quoting = csv.QUOTE_MINIMAL
-                
-                dialect = CustomDialect
-            
-            # 重置文件指针
-            f.seek(0)
-            
             # 使用csv模块读取表头
-            reader = csv.reader(f, dialect)
+            reader = csv.reader(
+                f,
+                delimiter=sep,
+                quotechar=quotechar,
+                doublequote=True,
+                skipinitialspace=True
+            )
             if has_header:
                 try:
                     raw_headers = next(reader)
@@ -664,7 +729,7 @@ def get_csv_info(csv_path, csv_props=None):
                 except StopIteration:
                     # 如果文件为空，提供一个默认表头
                     raw_headers = ["Column_1"]
-            
+
             # 清理表头（SQL安全版）
             cleaned_header = []
             for i, col in enumerate(raw_headers):
@@ -673,7 +738,7 @@ def get_csv_info(csv_path, csv_props=None):
                 else:
                     # 使用安全的列名清理
                     col = sanitize_column_name(str(col))
-                
+
                 # 确保唯一性
                 base_col = col
                 counter = 1
@@ -681,11 +746,11 @@ def get_csv_info(csv_path, csv_props=None):
                     col = f"{base_col}_{counter}"
                     counter += 1
                 cleaned_header.append(col)
-            
+
             # 估计行数
             # 先重置文件指针
             f.seek(0)
-            
+
             # 估算总行数
             file_size = os.path.getsize(csv_path)
             if file_size > 5*1024*1024:  # 如果文件大于5MB，使用估算方法
@@ -700,7 +765,7 @@ def get_csv_info(csv_path, csv_props=None):
                     line_count += 1
                     if i >= lines_to_check-1:
                         break
-                
+
                 if line_count > 0:
                     avg_line_length = total_chars / line_count
                     # 防止除零错误：确保avg_line_length不为0
@@ -716,7 +781,7 @@ def get_csv_info(csv_path, csv_props=None):
                 with open(csv_path, 'r', encoding=encoding, errors='replace') as count_f:
                     line_count = sum(1 for _ in count_f)
                     estimated_rows = line_count - (1 if has_header else 0)
-        
+
         # 包装返回结果，模拟Excel信息格式
         return {
             'sheet_names': ['Sheet1'],  # CSV视为单一工作表
@@ -733,12 +798,12 @@ def get_csv_info(csv_path, csv_props=None):
 def get_sample_data(file_path, sheet_name=None, sample_size=100, file_type=None, csv_props=None):
     """获取样本数据用于类型检测，支持Excel和CSV"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 检测文件类型（如果未提供）
         if file_type is None:
             file_type = detect_file_type(file_path)
-        
+
         if file_type == 'excel':
             # Excel处理逻辑
             df_sample = pd.read_excel(
@@ -754,7 +819,7 @@ def get_sample_data(file_path, sheet_name=None, sample_size=100, file_type=None,
             # 如果未提供CSV属性，则进行检测
             if csv_props is None:
                 csv_props = detect_csv_properties(file_path)
-            
+
             # 使用pandas读取CSV
             df_sample = pd.read_csv(
                 file_path,
@@ -765,14 +830,14 @@ def get_sample_data(file_path, sheet_name=None, sample_size=100, file_type=None,
                 header=0 if csv_props['has_header'] else None,
                 engine='python'  # 使用python引擎以处理复杂CSV
             )
-            
+
             # 如果没有表头，添加默认列名
             if not csv_props['has_header']:
                 df_sample.columns = [f"Column_{i+1}" for i in range(len(df_sample.columns))]
-        
+
         # 移除完全为空的行
         df_sample = df_sample.dropna(how='all')
-        
+
         # 优化内存使用 - 提取数据后立即清理
         try:
             # 先提取列名
@@ -792,32 +857,33 @@ def get_sample_data(file_path, sheet_name=None, sample_size=100, file_type=None,
 def get_merged_cells_info(file_path, sheet_name, file_type=None):
     """获取合并单元格信息，仅适用于Excel文件"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 检测文件类型（如果未提供）
         if file_type is None:
             file_type = detect_file_type(file_path)
-        
+
         if file_type != 'excel':
             # CSV文件没有合并单元格
             return []
-        
+
         # 读取工作簿以获取合并单元格信息
         wb = None
         try:
             wb = load_workbook(file_path, read_only=False, data_only=True)
             ws = wb[sheet_name]
-            
+
             # 获取所有合并单元格范围
             merged_ranges = []
             for merged_cell_range in ws.merged_cells.ranges:
                 min_row, min_col, max_row, max_col = (
-                    merged_cell_range.min_row, 
-                    merged_cell_range.min_col, 
+                    merged_cell_range.min_row,
+                    merged_cell_range.min_col,
                     merged_cell_range.max_row,
                     merged_cell_range.max_col
                 )
-                merged_ranges.append((min_row, min_col, max_row, max_col))
+                merged_value = ws.cell(row=min_row, column=min_col).value
+                merged_ranges.append((min_row, min_col, max_row, max_col, merged_value))
         finally:
             # 确保资源总是被释放
             if wb is not None:
@@ -825,7 +891,7 @@ def get_merged_cells_info(file_path, sheet_name, file_type=None):
                     wb.close()
                 except Exception as e:
                     logger.warning(f"关闭Excel工作簿失败: {e}")
-        
+
         return merged_ranges
     except Exception as e:
         logger.warning(f"获取合并单元格信息失败: {str(e)}")
@@ -835,12 +901,12 @@ def process_chunk(args):
     """处理单个数据块的函数(用于并行处理)，支持Excel和CSV"""
     chunk_id, file_path, sheet_name, skiprows, nrows, headers, merged_ranges, file_type, csv_props, transform_rules = args
     # 注意:这里增加了transform_rules参数!
-    
+
     # 每个进程使用独立的日志记录器（并发安全增强版）
     import threading
     worker_id = f"worker_{os.getpid()}_{threading.get_ident()}"
     worker_logger = logging.getLogger(worker_id)
-    
+
     # 使用更安全的handler检查，避免竞态条件
     if not worker_logger.hasHandlers():
         # 双重检查锁定模式（适用于多进程环境）
@@ -853,7 +919,7 @@ def process_chunk(args):
             worker_logger.addHandler(handler)
             worker_logger.setLevel(logging.WARNING)
             worker_logger.propagate = False  # 防止向父日志器传播
-    
+
     try:
         if file_type == 'excel':
             # Excel文件处理
@@ -864,28 +930,33 @@ def process_chunk(args):
                 nrows=nrows,
                 header=None
             )
-            
+
             # 处理合并单元格 - 复制值到所有被合并的单元格位置
             if merged_ranges:
-                for min_row, min_col, max_row, max_col in merged_ranges:
+                for merged_range in merged_ranges:
+                    min_row, min_col, max_row, max_col = merged_range[:4]
+                    merged_value = merged_range[4] if len(merged_range) > 4 else None
                     # 检查合并区域是否在当前块内
-                    chunk_min_row = min_row - skiprows
-                    chunk_max_row = max_row - skiprows
-                    
+                    chunk_start_excel_row = skiprows + 1
+                    chunk_min_row = min_row - chunk_start_excel_row
+                    chunk_max_row = max_row - chunk_start_excel_row
+
                     # 如果合并区域与当前数据块有交集
                     if chunk_min_row < df_chunk.shape[0] and chunk_max_row >= 0:
                         # 调整相对于当前块的行索引
                         chunk_min_row = max(0, chunk_min_row)
                         chunk_max_row = min(df_chunk.shape[0] - 1, chunk_max_row)
-                        
+
                         # 调整列索引(pandas是0-based，而openpyxl是1-based)
                         df_min_col = min_col - 1
                         df_max_col = min(df_chunk.shape[1] - 1, max_col - 1)
-                        
+
                         if chunk_min_row >= 0 and df_min_col >= 0:
                             try:
-                                cell_value = df_chunk.iloc[chunk_min_row, df_min_col]
-                                
+                                cell_value = merged_value
+                                if cell_value is None and chunk_min_row < df_chunk.shape[0]:
+                                    cell_value = df_chunk.iloc[chunk_min_row, df_min_col]
+
                                 for r in range(chunk_min_row, chunk_max_row + 1):
                                     for c in range(df_min_col, df_max_col + 1):
                                         if r < df_chunk.shape[0] and c < df_chunk.shape[1]:
@@ -904,10 +975,10 @@ def process_chunk(args):
                 header=None,
                 engine='python'  # 使用python引擎以处理复杂CSV
             )
-        
+
         # 移除完全为空的行
         df_chunk = df_chunk.dropna(how='all')
-        
+
         # 优化的数据处理 - 使用pandas向量化操作
         try:
             # 确保DataFrame列数与headers匹配
@@ -917,10 +988,10 @@ def process_chunk(args):
                 # 添加缺失的列
                 for i in range(len(df_chunk.columns), len(headers)):
                     df_chunk[f'temp_col_{i}'] = None
-            
+
             # 重新设置列名以匹配headers
             df_chunk.columns = headers[:len(df_chunk.columns)]
-            
+
             # 应用列转换规则（向量化操作）
             if transform_rules:
                 for header in headers:
@@ -928,7 +999,7 @@ def process_chunk(args):
                         df_chunk[header] = df_chunk[header].apply(
                             lambda x: apply_column_transformation(x, transform_rules[header])
                         )
-            
+
             # 向量化字符串清理（仅对字符串列）
             import unicodedata
             def clean_string_vectorized(x):
@@ -939,33 +1010,33 @@ def process_chunk(args):
                 x = x.replace('\t', ' ').replace('\f', ' ').replace('\v', ' ')
                 x = x.replace('\b', '').replace('\a', '')
                 # Unicode字符清理
-                return ''.join(char for char in x 
-                             if unicodedata.category(char) not in ('Cc', 'Cf') 
+                return ''.join(char for char in x
+                             if unicodedata.category(char) not in ('Cc', 'Cf')
                              or char in ' \t')
-            
+
             # 对所有字符串列应用清理
             string_cols = df_chunk.select_dtypes(include=['object']).columns
             for col in string_cols:
                 df_chunk[col] = df_chunk[col].apply(clean_string_vectorized)
-            
+
             # 处理NaN值 - 使用pandas的优化方法
             df_chunk = df_chunk.where(pd.notnull(df_chunk), None)
-            
+
             # 处理pandas Timestamp类型转换为字符串
             for col in df_chunk.columns:
                 if df_chunk[col].dtype.name.startswith('datetime'):
                     df_chunk[col] = df_chunk[col].dt.strftime('%Y-%m-%d %H:%M:%S')
                 elif any(isinstance(val, pd.Timestamp) for val in df_chunk[col].dropna().iloc[:5] if val is not None):
                     df_chunk[col] = df_chunk[col].apply(lambda x: x.strftime('%Y-%m-%d %H:%M:%S') if isinstance(x, pd.Timestamp) else x)
-            
+
             # 转换为元组列表（最后一步才转换以减少内存使用）
             processed_data = [tuple(row) for row in df_chunk.values]
-            
+
             # 显式清理DataFrame内存
             del df_chunk
             import gc
             gc.collect()
-            
+
         except Exception as e:
             # 回退到原始方法以确保兼容性
             worker_logger.warning(f"向量化处理失败，回退到行级处理: {e}")
@@ -986,21 +1057,21 @@ def process_chunk(args):
                             cell_value = cell_value.replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
                             cell_value = cell_value.replace('\t', ' ').replace('\f', ' ').replace('\v', ' ')
                             cell_value = cell_value.replace('\b', '').replace('\a', '')
-                            cell_value = ''.join(char for char in cell_value 
-                                               if unicodedata.category(char) not in ('Cc', 'Cf') 
+                            cell_value = ''.join(char for char in cell_value
+                                               if unicodedata.category(char) not in ('Cc', 'Cf')
                                                or char in ' \t')
                         processed_row.append(cell_value)
                 processed_data.append(tuple(processed_row))
-        
-        return chunk_id, processed_data
+
+        return chunk_id, processed_data, None
     except Exception as e:
         worker_logger.error(f"处理块 {chunk_id} 出错: {str(e)}")
-        return chunk_id, []
+        return chunk_id, [], str(e)
 
 # 数据库抽象基类
 class Database(ABC):
     """数据库操作抽象基类"""
-    
+
     def ensure_connection(self):
         """确保数据库连接有效，增强错误处理"""
         if not hasattr(self, 'conn') or self.conn is None:
@@ -1008,12 +1079,12 @@ class Database(ABC):
                 self.connect()
             except Exception as e:
                 raise ConnectionError(f"无法建立数据库连接: {str(e)}")
-        
+
         if self.conn is None:
             raise ConnectionError("数据库连接失败，连接对象为None")
-        
+
         return self.conn
-    
+
     def __del__(self):
         """析构函数，确保资源清理"""
         try:
@@ -1022,52 +1093,52 @@ class Database(ABC):
         except Exception:
             # 忽略析构函数中的异常，避免影响程序退出
             pass
-    
+
     @abstractmethod
     def connect(self):
         """连接到数据库"""
         pass
-    
+
     @abstractmethod
     def disconnect(self):
         """断开数据库连接"""
         pass
-    
+
     @abstractmethod
     def table_exists(self, table_name):
         """检查表是否存在"""
         pass
-    
+
     @abstractmethod
     def drop_table(self, table_name):
         """删除表"""
         pass
-    
+
     @abstractmethod
     def get_table_columns(self, table_name):
         """获取表的列信息"""
         pass
-    
+
     @abstractmethod
     def create_table(self, table_name, headers, column_types, has_pk=False):
         """创建表"""
         pass
-    
+
     @abstractmethod
     def write_data(self, table_name, headers, data_chunks, field_mapping=None):
         """写入数据"""
         pass
-    
+
     @abstractmethod
     def create_indices(self, table_name, headers, max_indices=3):
         """创建索引"""
         pass
-    
+
     @abstractmethod
     def optimize(self):
         """优化数据库"""
         pass
-    
+
     @abstractmethod
     def verify(self):
         """验证数据库"""
@@ -1076,13 +1147,13 @@ class Database(ABC):
 # SQLite数据库实现
 class SQLiteDatabase(Database):
     """SQLite数据库操作实现"""
-    
+
     def __init__(self, db_path):
         """初始化"""
         self.db_path = db_path
         self.conn = None
         self.logger = logging.getLogger(__name__)
-    
+
     def connect(self):
         """连接到SQLite数据库"""
         try:
@@ -1091,7 +1162,7 @@ class SQLiteDatabase(Database):
                 # 验证数据库路径安全性
                 safe_db_path = validate_safe_path(self.db_path)
                 self.db_path = safe_db_path  # 使用安全验证后的路径
-                
+
                 db_dir = os.path.dirname(self.db_path)
                 if db_dir:
                     # 验证目录路径的安全性
@@ -1100,16 +1171,16 @@ class SQLiteDatabase(Database):
             except ValueError as e:
                 self.logger.error(f"数据库路径安全验证失败: {e}")
                 raise ValueError(f"不安全的数据库路径: {e}")
-            
+
             # 创建连接
             self.conn = sqlite3.connect(self.db_path)
-            
+
             # 优化设置
             self.conn.execute('PRAGMA journal_mode = WAL')
             self.conn.execute('PRAGMA synchronous = NORMAL')
             self.conn.execute('PRAGMA cache_size = 100000')
             self.conn.execute('PRAGMA temp_store = MEMORY')
-            
+
             # 动态设置内存映射大小（更安全的限制）
             try:
                 available_memory = psutil.virtual_memory().available
@@ -1120,44 +1191,44 @@ class SQLiteDatabase(Database):
                     # 限制内存映射为可用内存的10%，最大256MB（更保守）
                     max_safe_mmap = min(int(available_memory * 0.1), 268435456)  # 256MB
                     mmap_size = max(max_safe_mmap, 67108864)  # 最小64MB
-                
+
                 # 设置内存映射大小
                 self.conn.execute(f'PRAGMA mmap_size = {mmap_size}')
             except Exception as e:
                 self.logger.warning(f"设置内存映射大小失败: {e}，使用默认设置")
                 mmap_size = 268435456  # 256MB 默认值
                 self.conn.execute(f'PRAGMA mmap_size = {mmap_size}')
-            
+
             self.logger.info(f"已连接到SQLite数据库: {self.db_path}")
             self.logger.info(f"已设置内存映射大小: {mmap_size / (1024**3):.1f} GB (可用内存: {available_memory / (1024**3):.1f} GB)")
-            
+
             return self.conn
         except Exception as e:
             self.logger.error(f"连接SQLite数据库出错: {str(e)}")
             raise
-    
+
     def disconnect(self):
         """断开SQLite连接"""
         if self.conn:
             self.conn.close()
             self.conn = None
             self.logger.info("已断开SQLite数据库连接")
-    
+
     def table_exists(self, table_name):
         """检查表是否存在"""
         if not self.conn:
             self.connect()
-        
+
         cursor = self.conn.cursor()
         cursor.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table_name,))
         return cursor.fetchone() is not None
-    
+
     def drop_table(self, table_name):
         """删除表"""
         try:
             # 确保连接有效，增强错误处理
             conn = self.ensure_connection()
-            
+
             # 使用严格的表名验证防止SQL注入
             safe_table_name = sanitize_table_name(table_name)
             conn.execute(f'DROP TABLE IF EXISTS "{safe_table_name}"')
@@ -1167,39 +1238,39 @@ class SQLiteDatabase(Database):
         except Exception as e:
             self.logger.error(f"删除表 {table_name} 出错: {str(e)}")
             return False
-    
+
     def get_table_columns(self, table_name):
         """获取表的列信息"""
         if not self.conn:
             self.connect()
-        
+
         try:
             cursor = self.conn.cursor()
             # 使用严格的表名验证防止SQL注入
             safe_table_name = sanitize_table_name(table_name)
             cursor.execute(f"PRAGMA table_info(\"{safe_table_name}\")")
             columns = cursor.fetchall()
-            
+
             # SQLite PRAGMA table_info 返回的格式: (cid, name, type, notnull, dflt_value, pk)
             column_info = {col[1]: {'type': col[2], 'position': col[0]} for col in columns}
             return column_info
         except Exception as e:
             self.logger.error(f"获取表 {table_name} 的列信息出错: {str(e)}")
             return {}
-    
+
     # 修改SQLiteDatabase.create_table方法
     def create_table(self, table_name, headers, column_types, has_pk=False):
         """创建SQLite表"""
         if not self.conn:
             self.connect()
-        
+
         try:
             column_defs = []
-            
+
             if has_pk:
                 # 第一列已是主键
                 column_defs.append(f'"{headers[0]}" {column_types[0]}')
-                
+
                 # 添加其他列（从索引1开始，类型也从索引1开始）
                 for i in range(1, len(headers)):
                     if i < len(column_types):
@@ -1207,24 +1278,25 @@ class SQLiteDatabase(Database):
                         column_defs.append(f'{safe_column} {column_types[i]}')
             else:
                 # 添加自增ID主键
-                column_defs.append('id INTEGER PRIMARY KEY AUTOINCREMENT')
-                
+                pk_name = generated_pk_name(headers)
+                column_defs.append(f'"{pk_name}" INTEGER PRIMARY KEY AUTOINCREMENT')
+
                 # 添加所有列（从索引0开始）
                 for i in range(len(headers)):
                     if i < len(column_types):
                         safe_column = f'"{headers[i]}"'
                         column_defs.append(f'{safe_column} {column_types[i]}')
-            
+
             # 创建表
             create_table_sql = f'''
             CREATE TABLE IF NOT EXISTS "{table_name}" (
                 {', '.join(column_defs)}
             )
             '''
-            
+
             self.conn.execute(create_table_sql)
             self.conn.commit()
-            
+
             self.logger.info(f"已创建SQLite表 '{table_name}' 包含 {len(headers)} 列")
             return True
         except Exception as e:
@@ -1235,21 +1307,23 @@ class SQLiteDatabase(Database):
         """将处理好的数据块写入SQLite数据库"""
         if not self.conn:
             self.connect()
-        
+
         try:
             total_rows = 0
-            
+
             # 如果有字段映射，使用映射后的字段列表
             if field_mapping:
-                # 过滤掉不在映射中的字段
-                excel_headers = [h for h in headers if h in field_mapping]
-                # 获取映射后的数据库列名
-                db_headers = [field_mapping[h] for h in excel_headers]
+                mapping_plan = build_mapping_plan(headers, field_mapping)
+                excel_headers = [source_header for _, source_header, _ in mapping_plan]
+                db_headers = [target_header for _, _, target_header in mapping_plan]
+                if not db_headers:
+                    self.logger.warning("字段映射没有匹配到任何可写入列")
+                    return 0
                 self.logger.debug(f"字段映射: Excel列名 -> 数据库列名: {dict(zip(excel_headers, db_headers))}")
             else:
-                excel_headers = headers
+                mapping_plan = None
                 db_headers = headers
-            
+
             # 准备批量插入的SQL语句 - 使用映射后的数据库列名
             placeholders = ', '.join(['?'] * len(db_headers))
             insert_sql = f'''
@@ -1257,16 +1331,13 @@ class SQLiteDatabase(Database):
                 {', '.join([f'"{col}"' for col in db_headers])}
             ) VALUES ({placeholders})
             '''
-            
+
             # 显式事务管理，提供更好的控制和错误处理
             cursor = self.conn.cursor()
             try:
                 # 开始事务
                 cursor.execute("BEGIN TRANSACTION")
-                
-                batch_size = 0
-                max_batch_size = 50000  # 批量提交阈值
-                
+
                 for chunk_data in data_chunks:
                     if chunk_data:
                         # 如果有字段映射，需要重新组织数据
@@ -1275,32 +1346,24 @@ class SQLiteDatabase(Database):
                             for row in chunk_data:
                                 # 只保留映射中的字段数据，并按映射后的顺序组织
                                 filtered_row = []
-                                for i, h in enumerate(headers):
-                                    if h in field_mapping:
-                                        val = row[i]
-                                        # 使用更准确的NaN检测方法
-                                        if is_nan_or_empty(val):
-                                            filtered_row.append(None)
-                                        else:
-                                            filtered_row.append(val)
+                                for i, _, _ in mapping_plan:
+                                    val = row[i] if i < len(row) else None
+                                    # 使用更准确的NaN检测方法
+                                    if is_nan_or_empty(val):
+                                        filtered_row.append(None)
+                                    else:
+                                        filtered_row.append(val)
                                 filtered_data.append(tuple(filtered_row))
-                            cursor.executemany(insert_sql, filtered_data)
-                            total_rows += len(filtered_data)
-                            batch_size += len(filtered_data)
+                            if filtered_data:
+                                cursor.executemany(insert_sql, filtered_data)
+                                total_rows += len(filtered_data)
                         else:
                             cursor.executemany(insert_sql, chunk_data)
                             total_rows += len(chunk_data)
-                            batch_size += len(chunk_data)
-                        
-                        # 批量提交策略：避免事务过大
-                        if batch_size >= max_batch_size:
-                            cursor.execute("COMMIT")
-                            cursor.execute("BEGIN TRANSACTION")
-                            batch_size = 0
-                
-                # 提交剩余的数据
+
+                # 所有块处理成功后再提交，避免部分导入成功后后续chunk失败
                 cursor.execute("COMMIT")
-                
+
             except Exception as e:
                 # 发生错误时回滚事务
                 try:
@@ -1310,34 +1373,34 @@ class SQLiteDatabase(Database):
                 raise e
             finally:
                 cursor.close()
-            
+
             self.logger.info(f"成功插入 {total_rows} 行数据到SQLite表 '{table_name}'")
             return total_rows
         except Exception as e:
             self.logger.error(f"写入SQLite出错: {str(e)}")
             raise
-    
+
     def create_indices(self, table_name, headers, max_indices=3):
         """在SQLite表上创建索引以提高查询性能"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("创建SQLite索引...")
-            
+
             # 索引关键词
             index_keywords = ['id', 'code', 'name', 'type', 'date', 'time', 'key', 'num', 'uuid', 'no']
-            
+
             # 查找可能适合索引的列
             index_candidates = []
             for i, col in enumerate(headers):
                 col_lower = col.lower()
                 if any(keyword in col_lower for keyword in index_keywords):
                     index_candidates.append((i, col))
-            
+
             # 限制索引数量
             index_candidates = index_candidates[:max_indices]
-            
+
             # 创建索引
             safe_table_name = sanitize_table_name(table_name)
             for idx, (_, col) in enumerate(index_candidates):
@@ -1346,19 +1409,19 @@ class SQLiteDatabase(Database):
                 idx_name = f"idx_{safe_table_name}_{idx}"
                 self.conn.execute(f'CREATE INDEX IF NOT EXISTS "{idx_name}" ON "{safe_table_name}" ("{safe_col}")')
                 self.logger.info(f"创建SQLite索引: {idx_name} 在列 '{safe_col}'")
-            
+
             self.conn.commit()
             self.logger.info(f"为SQLite表 '{safe_table_name}' 创建了 {len(index_candidates)} 个索引")
             return True
         except Exception as e:
             self.logger.error(f"创建SQLite索引出错: {str(e)}")
             return False
-    
+
     def optimize(self):
         """优化SQLite数据库"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("优化SQLite数据库...")
             self.conn.execute('VACUUM')
@@ -1368,23 +1431,23 @@ class SQLiteDatabase(Database):
         except Exception as e:
             self.logger.error(f"优化SQLite数据库出错: {str(e)}")
             return False
-    
+
     def verify(self):
         """验证生成的SQLite数据库"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("验证SQLite数据库...")
             cursor = self.conn.cursor()
-            
+
             # 获取所有表
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
             tables = cursor.fetchall()
-            
+
             self.logger.info(f"SQLite数据库包含 {len(tables)} 个表:")
             table_stats = []
-            
+
             for table in tables:
                 table_name = table[0]
                 # 使用安全的表名验证（即使数据来自数据库本身）
@@ -1392,20 +1455,20 @@ class SQLiteDatabase(Database):
                 # 获取行数
                 cursor.execute(f"SELECT COUNT(*) FROM \"{safe_table_name}\"")
                 row_count = cursor.fetchone()[0]
-                
+
                 # 获取列信息
                 cursor.execute(f"PRAGMA table_info(\"{safe_table_name}\")")
                 columns = cursor.fetchall()
-                
+
                 table_info = {
                     'table_name': table_name,
                     'row_count': row_count,
                     'column_count': len(columns)
                 }
                 table_stats.append(table_info)
-                
+
                 self.logger.info(f"表 '{table_name}': {row_count} 行, {len(columns)} 列")
-            
+
             self.logger.info("SQLite数据库验证完成")
             return table_stats
         except Exception as e:
@@ -1415,7 +1478,7 @@ class SQLiteDatabase(Database):
 # MySQL数据库实现
 class MySQLDatabase(Database):
     """MySQL数据库操作实现"""
-    
+
     def __init__(self, host, port, user, password, database, charset='utf8mb4'):
         """初始化"""
         self.host = host
@@ -1426,10 +1489,13 @@ class MySQLDatabase(Database):
         self.charset = charset
         self.conn = None
         self.logger = logging.getLogger(__name__)
-    
+
     def connect(self):
         """连接到MySQL数据库"""
         try:
+            if pymysql is None:
+                raise ImportError("缺少MySQL依赖 'pymysql'，请执行: pip install pymysql")
+
             # 创建连接
             self.conn = pymysql.connect(
                 host=self.host,
@@ -1441,7 +1507,7 @@ class MySQLDatabase(Database):
                 autocommit=False,
                 cursorclass=DictCursor  # 直接在连接参数中指定
             )
-            
+
             # 优化设置 - 保存原始安全配置并谨慎调整
             with self.conn.cursor() as cursor:
                 cursor.execute("SET autocommit = 0")
@@ -1454,13 +1520,13 @@ class MySQLDatabase(Database):
                 else:
                     self._original_unique_checks = 1
                     self._original_foreign_key_checks = 1
-                
+
                 # 仅在批量导入时临时禁用，并记录警告
                 self.logger.warning("临时禁用MySQL安全检查以提升导入性能，导入完成后将自动恢复")
                 cursor.execute("SET unique_checks = 0")
                 cursor.execute("SET foreign_key_checks = 0")
                 cursor.execute("SET sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION'")
-            
+
             self.logger.info(f"已连接到MySQL数据库: {self.host}:{self.port}/{self.database}")
             return self.conn
         except Exception as e:
@@ -1490,12 +1556,12 @@ class MySQLDatabase(Database):
                     self.logger.error(f"MySQL连接关闭失败: {e}")
                 self.conn = None
             self.logger.info("已断开MySQL数据库连接")
-    
+
     def table_exists(self, table_name):
         """检查表是否存在"""
         if not self.conn:
             self.connect()
-        
+
         with self.conn.cursor() as cursor:
             cursor.execute(
                 "SELECT COUNT(*) as count FROM information_schema.tables "
@@ -1504,12 +1570,12 @@ class MySQLDatabase(Database):
             )
             result = cursor.fetchone()
             return result['count'] > 0
-    
+
     def drop_table(self, table_name):
         """删除表"""
         if not self.conn:
             self.connect()
-        
+
         try:
             # 使用安全的表名验证防止SQL注入
             safe_table_name = sanitize_table_name(table_name)
@@ -1522,12 +1588,12 @@ class MySQLDatabase(Database):
             self.logger.error(f"删除MySQL表 {table_name} 出错: {str(e)}")
             self.conn.rollback()
             return False
-    
+
     def get_table_columns(self, table_name):
         """获取表的列信息"""
         if not self.conn:
             self.connect()
-        
+
         try:
             with self.conn.cursor() as cursor:
                 cursor.execute(
@@ -1537,7 +1603,7 @@ class MySQLDatabase(Database):
                     (self.database, table_name)
                 )
                 columns = cursor.fetchall()
-            
+
             column_info = {
                 col['COLUMN_NAME']: {
                     'type': col['DATA_TYPE'],
@@ -1549,20 +1615,20 @@ class MySQLDatabase(Database):
         except Exception as e:
             self.logger.error(f"获取MySQL表 {table_name} 的列信息出错: {str(e)}")
             return {}
-    
+
     # 修改MySQLDatabase.create_table方法
     def create_table(self, table_name, headers, column_types, has_pk=False):
         """创建MySQL表"""
         if not self.conn:
             self.connect()
-        
+
         try:
             column_defs = []
-            
+
             if has_pk:
                 # 第一列已是主键
                 column_defs.append(f'`{headers[0]}` {column_types[0]}')
-                
+
                 # 添加其他列（从索引1开始，类型也从索引1开始）
                 for i in range(1, len(headers)):
                     if i < len(column_types):
@@ -1570,25 +1636,26 @@ class MySQLDatabase(Database):
                         column_defs.append(f'{safe_column} {column_types[i]}')
             else:
                 # 添加自增ID主键
-                column_defs.append('`id` INT AUTO_INCREMENT PRIMARY KEY')
-                
+                pk_name = generated_pk_name(headers)
+                column_defs.append(f'`{pk_name}` INT AUTO_INCREMENT PRIMARY KEY')
+
                 # 添加所有列（从索引0开始）
                 for i in range(len(headers)):
                     if i < len(column_types):
                         safe_column = f'`{headers[i]}`'
                         column_defs.append(f'{safe_column} {column_types[i]}')
-            
+
             # 创建表
             create_table_sql = f'''
             CREATE TABLE IF NOT EXISTS `{table_name}` (
                 {', '.join(column_defs)}
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
             '''
-            
+
             with self.conn.cursor() as cursor:
                 cursor.execute(create_table_sql)
             self.conn.commit()
-            
+
             self.logger.info(f"已创建MySQL表 '{table_name}' 包含 {len(headers)} 列")
             return True
         except Exception as e:
@@ -1600,21 +1667,23 @@ class MySQLDatabase(Database):
         """将处理好的数据块写入MySQL数据库"""
         if not self.conn:
             self.connect()
-        
+
         try:
             total_rows = 0
-            
+
             # 如果有字段映射，使用映射后的字段列表
             if field_mapping:
-                # 过滤掉不在映射中的字段
-                excel_headers = [h for h in headers if h in field_mapping]
-                # 获取映射后的数据库列名
-                db_headers = [field_mapping[h] for h in excel_headers]
+                mapping_plan = build_mapping_plan(headers, field_mapping)
+                excel_headers = [source_header for _, source_header, _ in mapping_plan]
+                db_headers = [target_header for _, _, target_header in mapping_plan]
+                if not db_headers:
+                    self.logger.warning("字段映射没有匹配到任何可写入列")
+                    return 0
                 self.logger.debug(f"字段映射: Excel列名 -> 数据库列名: {dict(zip(excel_headers, db_headers))}")
             else:
-                excel_headers = headers
+                mapping_plan = None
                 db_headers = headers
-            
+
             # 准备批量插入的SQL语句 - 使用映射后的数据库列名
             placeholders = ', '.join(['%s'] * len(db_headers))
             insert_sql = f'''
@@ -1622,63 +1691,72 @@ class MySQLDatabase(Database):
                 {', '.join([f'`{col}`' for col in db_headers])}
             ) VALUES ({placeholders})
             '''
-            
+
             # 分批处理，避免过大的事务
             batch_size = 5000  # 每个批次的最大行数
-            
+
             # 优化：预计算字段映射索引
             if field_mapping:
-                mapped_indices = [i for i, h in enumerate(headers) if h in field_mapping]
+                mapped_indices = [i for i, _, _ in mapping_plan]
+                max_mapped_index = max(mapped_indices) if mapped_indices else -1
                 self.logger.info(f"字段映射优化：从{len(headers)}列优化到{len(mapped_indices)}列")
             else:
                 mapped_indices = None
-            
+                max_mapped_index = -1
+
             # 快速NaN检测函数
             def is_nan_fast(val):
                 return val is None or (isinstance(val, float) and val != val) or pd.isna(val)
-            
+
             # 确保连接有效，增强错误处理
             conn = self.ensure_connection()
             with conn.cursor() as cursor:
-                # 合并所有数据块以减少循环层级
-                all_data = []
-                for chunk_data in data_chunks:
-                    if not chunk_data:
-                        continue
-                    all_data.extend(chunk_data)
-                
-                if not all_data:
-                    self.logger.warning("没有数据需要插入到MySQL")
-                    return 0
-                
-                # 优化的数据处理 - 单次遍历
-                if field_mapping and mapped_indices:
-                    # 使用预计算的索引，避免每行查找
-                    filtered_data = [
-                        tuple(None if is_nan_fast(row[i]) else row[i] for i in mapped_indices)
-                        for row in all_data if len(row) > max(mapped_indices)
-                    ]
-                else:
-                    # 处理所有字段的NaN值 - 向量化处理
-                    filtered_data = [
-                        tuple(None if is_nan_fast(val) else val for val in row)
-                        for row in all_data
-                    ]
-                
-                # 优化的批量插入 - 减少提交频率
+                pending_batch = []
                 processed_batches = 0
-                for i in range(0, len(filtered_data), batch_size):
-                    batch = filtered_data[i:i+batch_size]
+                source_rows = 0
+
+                def flush_batch(force=False):
+                    nonlocal processed_batches, total_rows, pending_batch
+                    if not pending_batch or (not force and len(pending_batch) < batch_size):
+                        return
+
+                    batch = pending_batch
+                    pending_batch = []
                     cursor.executemany(insert_sql, batch)
                     total_rows += len(batch)
                     processed_batches += 1
-                    
-                    # 每10个批次或最后一批才提交，减少I/O
-                    if processed_batches % 10 == 0 or i + batch_size >= len(filtered_data):
-                        conn.commit()
-                        
-                self.logger.info(f"优化的批处理：处理{len(all_data)}行，{processed_batches}个批次")
-            
+
+
+                for chunk_data in data_chunks:
+                    if not chunk_data:
+                        continue
+
+                    source_rows += len(chunk_data)
+                    for row in chunk_data:
+                        if field_mapping and mapped_indices:
+                            if len(row) <= max_mapped_index:
+                                continue
+                            normalized_row = tuple(
+                                None if is_nan_fast(row[i]) else row[i]
+                                for i in mapped_indices
+                            )
+                        else:
+                            normalized_row = tuple(
+                                None if is_nan_fast(val) else val
+                                for val in row
+                            )
+
+                        pending_batch.append(normalized_row)
+                        flush_batch()
+
+                flush_batch(force=True)
+                if total_rows == 0:
+                    self.logger.warning("没有数据需要插入到MySQL")
+                    return 0
+
+                conn.commit()
+                self.logger.info(f"优化的批处理：处理{source_rows}行，{processed_batches}个批次")
+
             self.logger.info(f"成功插入 {total_rows} 行数据到MySQL表 '{table_name}'")
             return total_rows
         except Exception as e:
@@ -1690,28 +1768,28 @@ class MySQLDatabase(Database):
             except Exception as rollback_error:
                 self.logger.warning(f"回滚操作失败: {rollback_error}")
             raise
-    
+
     def create_indices(self, table_name, headers, max_indices=3):
         """在MySQL表上创建索引以提高查询性能"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("创建MySQL索引...")
-            
+
             # 索引关键词
             index_keywords = ['id', 'code', 'name', 'type', 'date', 'time', 'key', 'num', 'uuid', 'no']
-            
+
             # 查找可能适合索引的列
             index_candidates = []
             for i, col in enumerate(headers):
                 col_lower = col.lower()
                 if any(keyword in col_lower for keyword in index_keywords):
                     index_candidates.append((i, col))
-            
+
             # 限制索引数量
             index_candidates = index_candidates[:max_indices]
-            
+
             # 创建索引
             with self.conn.cursor() as cursor:
                 for idx, (_, col) in enumerate(index_candidates):
@@ -1723,7 +1801,7 @@ class MySQLDatabase(Database):
                         (self.database, table_name, idx_name)
                     )
                     result = cursor.fetchone()
-                    
+
                     if result['count'] == 0:
                         # 使用安全的表名和列名防止SQL注入
                         safe_table_name = sanitize_table_name(table_name)
@@ -1731,7 +1809,7 @@ class MySQLDatabase(Database):
                         safe_idx_name = f"idx_{safe_table_name}_{idx}"
                         cursor.execute(f"CREATE INDEX `{safe_idx_name}` ON `{safe_table_name}` (`{safe_col}`)")
                         self.logger.info(f"创建MySQL索引: {safe_idx_name} 在列 '{safe_col}'")
-            
+
             self.conn.commit()
             self.logger.info(f"为MySQL表 '{table_name}' 创建了 {len(index_candidates)} 个索引")
             return True
@@ -1739,15 +1817,15 @@ class MySQLDatabase(Database):
             self.logger.error(f"创建MySQL索引出错: {str(e)}")
             self.conn.rollback()
             return False
-    
+
     def optimize(self):
         """优化MySQL数据库表"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("优化MySQL数据库表...")
-            
+
             # 获取所有表
             with self.conn.cursor() as cursor:
                 cursor.execute(
@@ -1756,29 +1834,29 @@ class MySQLDatabase(Database):
                     (self.database,)
                 )
                 tables = cursor.fetchall()
-                
+
                 for table in tables:
                     table_name = table['table_name']
                     # 使用安全的表名防止SQL注入
                     safe_table_name = sanitize_table_name(table_name)
                     self.logger.info(f"优化表: {safe_table_name}")
                     cursor.execute(f"OPTIMIZE TABLE `{safe_table_name}`")
-            
+
             self.conn.commit()
             self.logger.info("MySQL数据库表优化完成")
             return True
         except Exception as e:
             self.logger.error(f"优化MySQL数据库出错: {str(e)}")
             return False
-    
+
     def verify(self):
         """验证MySQL数据库"""
         if not self.conn:
             self.connect()
-        
+
         try:
             self.logger.info("验证MySQL数据库...")
-            
+
             # 获取所有表
             with self.conn.cursor() as cursor:
                 cursor.execute(
@@ -1787,19 +1865,19 @@ class MySQLDatabase(Database):
                     (self.database,)
                 )
                 tables = cursor.fetchall()
-            
+
             self.logger.info(f"MySQL数据库包含 {len(tables)} 个表:")
             table_stats = []
-            
+
             for table in tables:
                 table_name = table['table_name']
-                
+
                 with self.conn.cursor() as cursor:
                     # 获取行数，使用安全的表名防止SQL注入
                     safe_table_name = sanitize_table_name(table_name)
                     cursor.execute(f"SELECT COUNT(*) as count FROM `{safe_table_name}`")
                     row_count = cursor.fetchone()['count']
-                    
+
                     # 获取列信息
                     cursor.execute(
                         "SELECT COUNT(*) as count FROM information_schema.columns "
@@ -1807,16 +1885,16 @@ class MySQLDatabase(Database):
                         (self.database, table_name)
                     )
                     column_count = cursor.fetchone()['count']
-                
+
                 table_info = {
                     'table_name': table_name,
                     'row_count': row_count,
                     'column_count': column_count
                 }
                 table_stats.append(table_info)
-                
+
                 self.logger.info(f"表 '{table_name}': {row_count} 行, {column_count} 列")
-            
+
             self.logger.info("MySQL数据库验证完成")
             return table_stats
         except Exception as e:
@@ -1826,7 +1904,7 @@ class MySQLDatabase(Database):
 # 数据库工厂类
 class DatabaseFactory:
     """数据库工厂类，用于创建不同类型的数据库连接"""
-    
+
     @staticmethod
     def create_database(db_type, **kwargs):
         """创建数据库连接"""
@@ -1847,48 +1925,48 @@ class DatabaseFactory:
 def parse_table_mapping(mapping_str):
     """解析表名映射字符串 'excel_sheet=db_table,excel_sheet2=db_table2'"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         mapping = {}
         if not mapping_str:
             return mapping
-            
+
         # 按逗号分割映射对
         mapping_pairs = mapping_str.split(',')
-        
+
         for pair in mapping_pairs:
             if not pair.strip():
                 continue
-                
+
             parts = pair.split('=', 1)
             if len(parts) != 2:
                 logger.warning(f"跳过无效的表映射: {pair}")
                 continue
-                
+
             excel_sheet = parts[0].strip()
             db_table = parts[1].strip()
-            
+
             if not excel_sheet or not db_table:
                 logger.warning(f"跳过空的表映射: {pair}")
                 continue
-                
+
             mapping[excel_sheet] = db_table
-        
+
         logger.info(f"已解析表映射配置，共 {len(mapping)} 个映射")
         return mapping
-        
+
     except Exception as e:
         logger.error(f"解析表映射出错: {str(e)}")
         return {}
 
 # 转换器主函数
 def file_to_database(
-    file_path, 
+    file_path,
     db_type,
     db_params,
-    sheet_name=None, 
-    chunk_size=20000, 
-    max_workers=None, 
+    sheet_name=None,
+    chunk_size=20000,
+    max_workers=None,
     max_indices=3,
     mode='overwrite',
     field_mode='create-all',
@@ -1900,39 +1978,40 @@ def file_to_database(
 ):
     """将Excel或CSV转换为数据库的主函数"""
     logger = logging.getLogger(__name__)
-    
+
     start_time = time.time()
-    
+
     # 如果未指定worker数量，使用CPU核心数减1
     if max_workers is None:
         max_workers = max(1, multiprocessing.cpu_count() - 1)
-    
+
     # 检测文件类型
     file_type = detect_file_type(file_path)
     logger.info(f"检测到文件类型: {file_type}")
-    
+
     # 验证支持的文件类型
     if file_type not in ['excel', 'csv']:
         logger.error(f"不支持的文件类型: {file_type}")
         return {'success': False, 'error': f"不支持的文件类型: {file_type}"}
-    
+
     logger.info(f"开始处理: {file_path} -> {db_type}")
     logger.info(f"使用 {max_workers} 个工作进程，每块 {chunk_size} 行")
     logger.info(f"操作模式: {mode}, 字段处理模式: {field_mode}")
-    
+
+    db = None
     try:
         # 根据文件类型获取文件信息
         csv_props = None
         if file_type == 'excel':
             file_info = get_excel_info(file_path, sheet_name)
             sheet_names = file_info['sheet_names']
-            
+
             # 如果指定了表名，仅处理该表
             if sheet_name is not None:
                 sheets_to_process = [file_info['current_sheet']]
             else:
                 sheets_to_process = sheet_names
-            
+
             logger.info(f"Excel文件包含 {len(sheet_names)} 个工作表: {', '.join(sheet_names)}")
             logger.info(f"将处理以下工作表: {', '.join(sheets_to_process)}")
         else:  # CSV文件
@@ -1941,33 +2020,35 @@ def file_to_database(
                 csv_props = csv_params
             else:
                 csv_props = detect_csv_properties(file_path)
-            
+
             file_info = get_csv_info(file_path, csv_props)
             logger.info(f"CSV文件编码: {csv_props['encoding']}, 分隔符: {repr(csv_props['sep'])}")
-            
+
             # CSV文件只有一个工作表
             sheets_to_process = ['Sheet1']
-        
+
         # 创建数据库连接
         db = DatabaseFactory.create_database(db_type, **db_params)
         db.connect()
-        
+
         total_rows_processed = 0
         results = []
-        
+
         for current_sheet in sheets_to_process:
             logger.info(f"开始处理工作表: {current_sheet}")
             sheet_start_time = time.time()
-            
+
             # 获取表头和估计行数
             if file_type == 'excel':
                 sheet_info = get_excel_info(file_path, current_sheet)
                 headers = sheet_info['headers']
+                raw_headers = sheet_info.get('raw_headers', headers)
                 estimated_rows = sheet_info['estimated_rows']
             else:  # CSV文件
                 headers = file_info['headers']
+                raw_headers = file_info.get('raw_headers', headers)
                 estimated_rows = file_info['estimated_rows']
-            
+
             # 确定目标表名: 表映射 > 单一目标表 > 工作表名
             if file_type == 'excel' and table_mapping and current_sheet in table_mapping:
                 # 优先使用表映射中指定的表名
@@ -1985,34 +2066,37 @@ def file_to_database(
 
             # 确保表名合法性（SQL安全版）
             table_name = sanitize_table_name(table_name)
-            
+
             logger.info(f"工作表 '{current_sheet}' 信息: {len(headers)} 列, 约 {estimated_rows} 行")
-            
+
             # 检查目标表是否存在
             table_exists = db.table_exists(table_name)
             excel_to_db_mapping = None
             used_headers = headers  # 默认使用所有列
             transform_rules = {}    # 字段转换规则
-            
+            effective_field_mode = field_mode
+
             # 处理字段映射和转换规则
             if field_mapping and current_sheet in field_mapping:
                 sheet_mapping = field_mapping[current_sheet]
                 if sheet_mapping:
                     logger.info(f"使用自定义映射处理工作表 '{current_sheet}'")
-                    field_mode = 'mapping'  # 强制使用映射模式
-                    
+                    effective_field_mode = 'mapping'  # 强制使用映射模式
+
                     # 转换为 {excel列名: 数据库列名} 格式
-                    excel_to_db_mapping = sheet_mapping
-                    
+                    excel_to_db_mapping = normalize_field_mapping(sheet_mapping, raw_headers, headers)
+
                     # 获取使用到的Excel列
                     used_headers = list(excel_to_db_mapping.keys())
-                    logger.info(f"映射配置包含 {len(used_headers)} 个字段")
-            
+                    logger.info(f"映射配置包含 {len(used_headers)} 个有效字段")
+                    if not excel_to_db_mapping:
+                        raise ValueError(f"工作表 '{current_sheet}' 的字段映射没有匹配到任何源字段")
+
             # 应用列转换规则
             if column_transforms and current_sheet in column_transforms:
-                transform_rules = column_transforms[current_sheet]
+                transform_rules = normalize_transform_rules(column_transforms[current_sheet], raw_headers, headers)
                 logger.info(f"应用 {len(transform_rules)} 个字段转换规则")
-            
+
             # 处理表和字段映射
             if table_exists:
                 if mode == 'overwrite':
@@ -2020,17 +2104,17 @@ def file_to_database(
                     logger.info(f"覆盖模式: 删除已有表 '{table_name}'")
                     db.drop_table(table_name)
                     table_exists = False
-                elif field_mode == 'match-only':
+                elif effective_field_mode == 'match-only':
                     # 追加模式 + 匹配字段，获取目标表的字段信息
                     logger.info(f"追加模式 + 匹配字段: 获取目标表 '{table_name}' 的字段信息")
                     table_columns = db.get_table_columns(table_name)
-                    
+
                     # 创建字段映射 {源字段名: 目标字段位置}
                     source_to_target_pos = {}
                     for i, header in enumerate(headers):
                         if header in table_columns:
                             source_to_target_pos[header] = table_columns[header]['position']
-                    
+
                     if source_to_target_pos:
                         logger.info(f"找到 {len(source_to_target_pos)} 个匹配的字段")
                         excel_to_db_mapping = {h: h for h in source_to_target_pos.keys()}
@@ -2038,17 +2122,17 @@ def file_to_database(
                     else:
                         logger.warning(f"目标表 '{table_name}' 没有匹配的字段，将跳过")
                         continue
-                elif field_mode == 'mapping' and excel_to_db_mapping:
+                elif effective_field_mode == 'mapping' and excel_to_db_mapping:
                     # 映射模式 + 追加，验证目标列是否存在
                     logger.info(f"映射模式 + 追加: 验证目标表 '{table_name}' 中的映射字段")
                     table_columns = db.get_table_columns(table_name)
-                    
+
                     # 检查目标列是否都存在
                     # 注意: 需要使用映射后的数据库列名进行检查
                     target_columns = set(excel_to_db_mapping.values())
                     existing_columns = set(table_columns.keys())
                     missing_columns = target_columns - existing_columns
-                    
+
                     if missing_columns:
                         logger.warning(f"目标表中缺少映射的字段: {', '.join(missing_columns)}")
                         # 过滤掉映射到不存在列的映射
@@ -2056,70 +2140,64 @@ def file_to_database(
                             excel_col: db_col for excel_col, db_col in excel_to_db_mapping.items()
                             if db_col in existing_columns
                         }
-                        
+
                     if not excel_to_db_mapping:
                         logger.warning(f"映射后没有可用字段，将跳过")
                         continue
-                        
+
                     used_headers = list(excel_to_db_mapping.keys())
-            
+
             # 获取样本数据并检测类型
             if not table_exists:
-                sample_data, _ = get_sample_data(file_path, current_sheet if file_type == 'excel' else None, 
+                sample_data, _ = get_sample_data(file_path, current_sheet if file_type == 'excel' else None,
                                               file_type=file_type, csv_props=csv_props)
-                
-                if field_mode == 'mapping' and excel_to_db_mapping:
+
+                if effective_field_mode == 'mapping' and excel_to_db_mapping:
                     # 使用映射创建表
-                    # 从样本数据中提取出映射的列
-                    mapped_headers = list(excel_to_db_mapping.values())
-                    
+                    # 从样本数据中提取出映射的列，顺序与后续写入保持一致
+                    mapping_plan = build_mapping_plan(headers, excel_to_db_mapping)
+                    mapped_headers = [target_header for _, _, target_header in mapping_plan]
+
                     # 创建一个新的样本数据集，仅包含映射的列
                     mapped_sample = []
                     for row in sample_data:
                         mapped_row = []
-                        for i, header in enumerate(headers):
-                            if header in excel_to_db_mapping and i < len(row):
-                                mapped_row.append(row[i])
+                        for i, _, _ in mapping_plan:
+                            mapped_row.append(row[i] if i < len(row) else None)
                         if mapped_row:  # 只添加非空行
                             mapped_sample.append(mapped_row)
-                    
+
                     column_types = detect_column_types(mapped_sample, mapped_headers, db_type)
-                    
-                    # 检查是否第一列为主键
-                    has_pk = any('PRIMARY KEY' in ct for ct in column_types[:1]) if column_types else False
-                    
+
                     # 创建表结构 - 使用映射后的列名
-                    db.create_table(table_name, mapped_headers, column_types, has_pk)
+                    db.create_table(table_name, mapped_headers, column_types, has_pk=False)
                 else:
                     # 常规创建表
                     column_types = detect_column_types(sample_data, headers, db_type)
-                    
-                    # 检查是否第一列为主键
-                    has_pk = any('PRIMARY KEY' in ct for ct in column_types[:1]) if column_types else False
-                    
+
                     # 创建表结构
-                    db.create_table(table_name, headers, column_types, has_pk)
-            
+                    db.create_table(table_name, headers, column_types, has_pk=False)
+
             # 获取合并单元格信息（仅Excel文件）
             merged_ranges = []
             if file_type == 'excel':
                 merged_ranges = get_merged_cells_info(file_path, current_sheet)
                 if merged_ranges:
                     logger.info(f"检测到 {len(merged_ranges)} 个合并单元格区域，将自动处理")
-            
+
             # 计算块数
             total_chunks = (estimated_rows + chunk_size - 1) // chunk_size
             logger.info(f"将分成 {total_chunks} 个数据块并行处理")
-            
+
             pbar = tqdm(
-                total=estimated_rows, 
+                total=estimated_rows,
                 desc=f"处理 {current_sheet}",
                 unit="行",
                 unit_scale=True,
                 ncols=100,
                 bar_format='{l_bar}{bar:30}{r_bar}{bar:-30b}'
             )
-            
+
             # 在file_to_database函数中的"准备并行任务"部分
             # 准备并行任务
             tasks = []
@@ -2128,46 +2206,43 @@ def file_to_database(
                 skiprows = chunk_id * chunk_size  # 跳过已处理行
                 if file_type == 'excel' or (file_type == 'csv' and csv_props['has_header']):
                     skiprows += 1  # 额外跳过表头行
-                
-                tasks.append((chunk_id, file_path, current_sheet, skiprows, chunk_size, 
+
+                tasks.append((chunk_id, file_path, current_sheet, skiprows, chunk_size,
                             headers, merged_ranges, file_type, csv_props, transform_rules))
-            
+
             processed_rows = 0
-            with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
-                futures = {
-                    executor.submit(process_chunk, t): t[0]
-                    for t in tasks
-                }
-                # 使用字典存储数据块，避免O(n²)排序算法
-                data_chunks_dict = {}
+
+            def processed_chunk_iter():
+                nonlocal processed_rows
                 completed_chunks = 0
-                
-                for future in concurrent.futures.as_completed(futures):
-                    chunk_id, chunk_data = future.result()
-                    if chunk_data:
-                        # 直接存储到字典中，保持O(1)复杂度
-                        data_chunks_dict[chunk_id] = chunk_data
-                        processed_rows += len(chunk_data)
-                        pbar.update(len(chunk_data))
-                    
-                    completed_chunks += 1
-                    # 每处理5个块进行一次内存清理
-                    if completed_chunks % 5 == 0:
-                        gc.collect()
-            
-            pbar.close()
-            
-            # 整理后写入数据库 - 按chunk_id排序确保数据顺序正确
-            sorted_chunks = sorted(data_chunks_dict.items())
-            chunk_data_only = [chunk_data for _, chunk_data in sorted_chunks]
-            logger.info("将处理好的数据写入数据库...")
-            total_inserted = db.write_data(table_name, headers, chunk_data_only, excel_to_db_mapping)
+
+                with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+                    for chunk_id, chunk_data, chunk_error in executor.map(process_chunk, tasks):
+                        if chunk_error:
+                            raise RuntimeError(f"处理块 {chunk_id} 失败: {chunk_error}")
+
+                        if chunk_data:
+                            processed_rows += len(chunk_data)
+                            pbar.update(len(chunk_data))
+                            yield chunk_data
+
+                        completed_chunks += 1
+                        # 每处理5个块进行一次内存清理
+                        if completed_chunks % 5 == 0:
+                            gc.collect()
+
+            logger.info("开始并行处理并写入数据库...")
+            try:
+                total_inserted = db.write_data(table_name, headers, processed_chunk_iter(), excel_to_db_mapping)
+            finally:
+                pbar.close()
             logger.info(f"成功插入 {total_inserted} 行数据到表 '{table_name}'")
-            
+
             # 创建索引（只在覆盖模式或表不存在时）
             if mode == 'overwrite' or not table_exists:
-                db.create_indices(table_name, headers, max_indices)
-            
+                index_headers = mapped_headers_in_source_order(headers, excel_to_db_mapping) if excel_to_db_mapping else headers
+                db.create_indices(table_name, index_headers, max_indices)
+
             sheet_time = time.time() - sheet_start_time
             results.append({
                 'sheet_name': current_sheet,
@@ -2175,35 +2250,33 @@ def file_to_database(
                 'rows_processed': processed_rows,
                 'time_seconds': sheet_time
             })
-            
+
             total_rows_processed += processed_rows
-            
+
             logger.info(f"工作表 '{current_sheet}' 处理完成! 耗时: {sheet_time:.2f} 秒")
-            
+
             # 清理内存
-            data_chunks_dict = None
-            sorted_chunks = None
-            chunk_data_only = None
             gc.collect()
-        
+
         # 全部完成后优化数据库
         db.optimize()
-        
+
         # 验证数据库
         db.verify()
-        
+
         # 断开连接
         db.disconnect()
-        
+        db = None
+
         end_time = time.time()
         total_time = end_time - start_time
-        
+
         logger.info(f"处理完成! 总共处理 {total_rows_processed} 行数据")
         logger.info(f"总耗时: {total_time:.2f} 秒")
-        
+
         if total_time > 0:
             logger.info(f"平均处理速度: {total_rows_processed / total_time:.2f} 行/秒")
-        
+
         return {
             'success': True,
             'file_path': file_path,
@@ -2214,9 +2287,14 @@ def file_to_database(
             'time_seconds': total_time,
             'sheet_results': results
         }
-    
+
     except Exception as e:
         logger.error(f"处理过程中出错: {str(e)}", exc_info=True)
+        if db is not None:
+            try:
+                db.disconnect()
+            except Exception as disconnect_error:
+                logger.warning(f"异常清理数据库连接失败: {disconnect_error}")
         return {
             'success': False,
             'error': str(e)
@@ -2235,102 +2313,102 @@ def get_mysql_password(args):
 def load_field_mapping(mapping_file):
     """从JSON或CSV文件加载字段映射配置"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         if not os.path.exists(mapping_file):
             logger.error(f"映射文件不存在: {mapping_file}")
             return None
-            
+
         file_ext = os.path.splitext(mapping_file)[1].lower()
-        
+
         if file_ext == '.json':
             # JSON格式: {sheet_name: {excel_column: db_column, ...}, ...}
             import json
             with open(mapping_file, 'r', encoding='utf-8') as f:
                 mapping = json.load(f)
-                
+
             # 验证格式
             if not isinstance(mapping, dict):
                 logger.error("映射文件格式错误: 应为字典格式")
                 return None
-                
+
             logger.info(f"已加载JSON映射文件: {mapping_file}")
             return mapping
-            
+
         elif file_ext == '.csv':
             # CSV格式: sheet_name,excel_column,db_column
             mapping = {}
-            
+
             with open(mapping_file, 'r', encoding='utf-8') as f:
                 import csv
                 reader = csv.reader(f)
                 next(reader)  # 跳过表头行
-                
+
                 for row in reader:
                     if len(row) < 3:
                         continue
-                        
+
                     sheet_name, excel_col, db_col = row[0], row[1], row[2]
-                    
+
                     if sheet_name not in mapping:
                         mapping[sheet_name] = {}
-                        
+
                     mapping[sheet_name][excel_col] = db_col
-            
+
             logger.info(f"已加载CSV映射文件: {mapping_file}")
             return mapping
-            
+
         else:
             logger.error(f"不支持的映射文件格式: {file_ext}")
             return None
-            
+
     except Exception as e:
         logger.error(f"加载映射文件出错: {str(e)}")
         return None
-        
+
 def parse_inline_mapping(mapping_str):
     """解析内联映射字符串 'sheet:excol1=dbcol1,excol2=dbcol2;sheet2:...'"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         mapping = {}
-        
+
         # 按工作表分割
         sheet_mappings = mapping_str.split(';')
-        
+
         for sheet_mapping in sheet_mappings:
             if not sheet_mapping.strip():
                 continue
-                
+
             # 分离工作表名和映射
             parts = sheet_mapping.strip().split(':', 1)
             if len(parts) != 2:
                 logger.warning(f"跳过无效的映射: {sheet_mapping}")
                 continue
-                
+
             sheet_name, column_mappings = parts
             sheet_name = sheet_name.strip()
-            
+
             if sheet_name not in mapping:
                 mapping[sheet_name] = {}
-                
+
             # 处理列映射
             column_pairs = column_mappings.split(',')
             for pair in column_pairs:
                 if not pair.strip():
                     continue
-                    
+
                 col_parts = pair.split('=', 1)
                 if len(col_parts) != 2:
                     logger.warning(f"跳过无效的列映射: {pair}")
                     continue
-                    
+
                 excel_col, db_col = col_parts[0].strip(), col_parts[1].strip()
                 mapping[sheet_name][excel_col] = db_col
-        
+
         logger.info(f"已解析内联映射配置，包含 {len(mapping)} 个工作表")
         return mapping
-        
+
     except Exception as e:
         logger.error(f"解析内联映射出错: {str(e)}")
         return None
@@ -2339,11 +2417,11 @@ def apply_column_transformation(excel_value, transform_rule):
     """应用字段转换规则"""
     if not transform_rule or excel_value is None:
         return excel_value
-        
+
     # 转换规则示例: 'uppercase', 'lowercase', 'trim', 'prefix:ABC', 'suffix:XYZ', 'replace:old,new'
     rule_parts = transform_rule.split(':', 1)
     rule_name = rule_parts[0].lower()
-    
+
     if rule_name == 'uppercase':
         return str(excel_value).upper()
     elif rule_name == 'lowercase':
@@ -2378,40 +2456,40 @@ def apply_column_transformation(excel_value, transform_rule):
 def parse_column_transform(transform_str):
     """解析列转换规则字符串 'sheet:column:rule;...'"""
     logger = logging.getLogger(__name__)
-    
+
     try:
         transforms = {}
-        
+
         if not transform_str:
             return transforms
-            
+
         # 按分号分割不同的转换规则
         rule_items = transform_str.split(';')
-        
+
         for item in rule_items:
             if not item.strip():
                 continue
-                
+
             # 分割工作表、列和规则
             parts = item.strip().split(':', 2)
             if len(parts) != 3:
                 logger.warning(f"跳过无效的转换规则: {item}")
                 continue
-                
+
             sheet_name, column_name, rule = [p.strip() for p in parts]
-            
+
             if not sheet_name or not column_name or not rule:
                 logger.warning(f"跳过空的转换规则: {item}")
                 continue
-                
+
             if sheet_name not in transforms:
                 transforms[sheet_name] = {}
-                
+
             transforms[sheet_name][column_name] = rule
-        
+
         logger.info(f"已解析列转换规则，共 {len(transforms)} 个工作表")
         return transforms
-        
+
     except Exception as e:
         logger.error(f"解析列转换规则出错: {str(e)}")
         return {}
@@ -2419,64 +2497,64 @@ def parse_column_transform(transform_str):
 # 命令行入口
 def main():
     parser = argparse.ArgumentParser(description='通用Excel/CSV到SQLite/MySQL转换工具')
-    
+
     parser.add_argument('file_path', nargs='?', help='输入文件路径 (Excel/CSV)')
-    
+
     # 数据库类型和参数
     parser.add_argument('--db-type', choices=['sqlite', 'mysql'], default='sqlite',
                         help='目标数据库类型 (sqlite 或 mysql)')
-    
+
     # SQLite参数
     parser.add_argument('--sqlite-path', help='SQLite数据库输出路径')
-    
+
     # MySQL参数
     parser.add_argument('--mysql-host', default='localhost', help='MySQL主机地址')
     parser.add_argument('--mysql-port', type=int, default=3306, help='MySQL端口')
     parser.add_argument('--mysql-user', default='root', help='MySQL用户名')
     parser.add_argument('--mysql-password', help='MySQL密码 (不提供则交互式输入)')
     parser.add_argument('--mysql-database', help='MySQL数据库名')
-    
+
     # CSV特定参数
     parser.add_argument('--csv-encoding', help='CSV文件编码 (默认自动检测)')
     parser.add_argument('--csv-separator', help='CSV分隔符 (默认自动检测)')
     parser.add_argument('--csv-quotechar', default='"', help='CSV引号字符 (默认: ")')
     parser.add_argument('--csv-no-header', action='store_true', help='CSV文件没有表头')
-    
+
     # 通用参数
-    parser.add_argument('-w', '--workers', type=int, default=None, 
+    parser.add_argument('-w', '--workers', type=int, default=None,
                         help='工作进程数量 (默认为CPU核心数-1)')
-    parser.add_argument('-c', '--chunk-size', type=int, default=20000, 
+    parser.add_argument('-c', '--chunk-size', type=int, default=20000,
                         help='数据块大小 (默认: 20000)')
-    parser.add_argument('-v', '--verbose', action='store_true', 
+    parser.add_argument('-v', '--verbose', action='store_true',
                         help='启用详细日志')
     parser.add_argument('-s', '--sheet', help='仅处理指定的工作表 (仅适用于Excel)')
-    parser.add_argument('-l', '--list-sheets', action='store_true', 
+    parser.add_argument('-l', '--list-sheets', action='store_true',
                         help='仅列出Excel中的工作表')
     parser.add_argument('-i', '--max-indices', type=int, default=3,
                         help='每个表创建的最大索引数量')
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='减少输出信息，仅显示关键进度')
-    
+
     # 操作模式相关参数
     parser.add_argument('--mode', choices=['overwrite', 'append'], default='overwrite',
                         help='操作模式: overwrite=覆盖现有表, append=追加到现有表 (默认: overwrite)')
     parser.add_argument('--field-mode', choices=['create-all', 'match-only', 'mapping'], default='create-all',
                         help='字段处理模式: create-all=创建所有字段, match-only=仅处理目标已有字段, mapping=使用映射配置 (默认: create-all)')
-    
+
     # 字段映射相关参数
     parser.add_argument('--mapping-file', help='字段映射配置文件路径(JSON或CSV格式)')
     parser.add_argument('--mapping', help='内联字段映射配置(格式:sheet:excol1=dbcol1,excol2=dbcol2;sheet2:...)')
     parser.add_argument('--column-transform', help='字段转换规则(格式:sheet:column:rule;...)，规则包括uppercase,lowercase,trim,prefix:X,suffix:X,replace:old,new,date_format:format')
-    
+
     # 表名相关参数
     parser.add_argument('--target-table', help='指定目标数据库表名（覆盖默认的工作表名）')
     parser.add_argument('--table-mapping', help='工作表到数据库表的映射 (格式:excel_sheet=db_table,excel_sheet2=db_table2)')
-    
+
     args = parser.parse_args()
-    
+
     # 设置日志
     log_level = logging.ERROR if args.quiet else (logging.DEBUG if args.verbose else logging.INFO)
-    
+
     # 必要依赖检查
     try:
         import chardet
@@ -2484,20 +2562,20 @@ def main():
         print("错误: 缺少必要的依赖项 'chardet'")
         print("请执行以下命令安装: pip install chardet")
         sys.exit(1)
-    
+
     # 如果只想列出工作表
     if args.list_sheets:
         if not args.file_path:
             print("错误: 未指定输入文件路径")
             sys.exit(1)
-            
+
         setup_logger(log_level)
-        
+
         file_type = detect_file_type(args.file_path)
         if file_type != 'excel':
             print("错误: --list-sheets 选项仅适用于Excel文件")
             sys.exit(1)
-            
+
         try:
             excel_info = get_excel_info(args.file_path)
             print("Excel文件包含以下工作表:")
@@ -2507,43 +2585,43 @@ def main():
         except Exception as e:
             print(f"错误: {str(e)}")
             sys.exit(1)
-    
+
     # 必要参数检查
     if not args.file_path:
         parser.print_help()
         sys.exit(1)
-    
+
     if not os.path.exists(args.file_path):
         print(f"错误: 输入文件 '{args.file_path}' 不存在")
         sys.exit(1)
-    
+
     # 根据数据库类型验证参数
     if args.db_type == 'sqlite':
         if not args.sqlite_path:
             print("错误: 使用SQLite时必须指定 --sqlite-path 参数")
             sys.exit(1)
-        
+
         # 设置日志文件
         log_file = f"{os.path.splitext(args.sqlite_path)[0]}_conversion.log"
         setup_logger(log_level, log_file)
-        
+
         # 构建SQLite参数
         db_params = {
             'db_path': args.sqlite_path
         }
-    
+
     elif args.db_type == 'mysql':
         if not args.mysql_database:
             print("错误: 使用MySQL时必须指定 --mysql-database 参数")
             sys.exit(1)
-        
+
         # 获取MySQL密码
         mysql_password = get_mysql_password(args)
-        
+
         # 设置日志文件
         log_file = f"mysql_{args.mysql_database}_conversion.log"
         setup_logger(log_level, log_file)
-        
+
         # 构建MySQL参数
         db_params = {
             'host': args.mysql_host,
@@ -2552,70 +2630,48 @@ def main():
             'password': mysql_password,
             'database': args.mysql_database
         }
-    
+
     # 解析字段映射
     field_mapping = None
     if args.mapping_file:
         field_mapping = load_field_mapping(args.mapping_file)
     elif args.mapping:
         field_mapping = parse_inline_mapping(args.mapping)
-    
+
     # 解析字段转换规则
     column_transforms = None
     if args.column_transform:
         column_transforms = parse_column_transform(args.column_transform)
-    
+
     # 解析表映射参数
     table_mapping = None
     if args.table_mapping:
         table_mapping = parse_table_mapping(args.table_mapping)
-    
+
     # 解析CSV特定参数
     csv_params = None
     file_type = detect_file_type(args.file_path)
     if file_type == 'csv':
+        quotechar_provided = any(
+            arg == '--csv-quotechar' or arg.startswith('--csv-quotechar=')
+            for arg in sys.argv[1:]
+        )
         # 如果提供了CSV特定参数，构建参数字典
-        if args.csv_encoding or args.csv_separator or args.csv_no_header:
-            csv_params = {}
-            
-            # 如果指定了编码，使用指定的；否则自动检测
+        if args.csv_encoding or args.csv_separator or args.csv_no_header or quotechar_provided:
+            csv_params = detect_csv_properties(args.file_path)
+
             if args.csv_encoding:
                 csv_params['encoding'] = args.csv_encoding
-            else:
-                # 检测编码
-                with open(args.file_path, 'rb') as f:
-                    sample = f.read(4096)
-                result = chardet.detect(sample)
-                # 防御性处理
-                if result and result.get('confidence', 0) > 0.7 and result.get('encoding'):
-                    csv_params['encoding'] = result['encoding']
-                else:
-                    csv_params['encoding'] = 'utf-8'
-            
-            # 如果指定了分隔符，使用指定的；否则自动检测
+
             if args.csv_separator:
                 csv_params['sep'] = args.csv_separator
-            else:
-                # 简单检测分隔符
-                with open(args.file_path, 'r', encoding=csv_params['encoding'], errors='replace') as f:
-                    sample = f.read(4096)
-                    comma_count = sample.count(',')
-                    semicolon_count = sample.count(';')
-                    tab_count = sample.count('\t')
-                    
-                    if tab_count > comma_count and tab_count > semicolon_count:
-                        csv_params['sep'] = '\t'
-                    elif semicolon_count > comma_count:
-                        csv_params['sep'] = ';'
-                    else:
-                        csv_params['sep'] = ','
-            
-            # 设置引号字符
-            csv_params['quotechar'] = args.csv_quotechar
-            
-            # 设置是否有表头
-            csv_params['has_header'] = not args.csv_no_header
-    
+
+            if quotechar_provided:
+                csv_params['quotechar'] = args.csv_quotechar
+
+            if args.csv_no_header:
+                csv_params['has_header'] = False
+
     # 执行转换
     result = file_to_database(
         file_path=args.file_path,
@@ -2633,17 +2689,17 @@ def main():
         table_mapping=table_mapping,
         csv_params=csv_params
     )
-    
+
     if result['success']:
         print("\n转换成功完成!")
         if args.db_type == 'sqlite':
             print(f"SQLite数据库已保存到: {args.sqlite_path}")
         else:
             print(f"数据已导入到MySQL数据库: {args.mysql_database}")
-            
+
         print(f"总共处理了 {result['total_rows']} 行数据，耗时 {result['time_seconds']:.2f} 秒")
         print(f"文件类型: {result['file_type'].upper()}")
-        
+
         if len(result['sheet_results']) > 1:
             print("\n各工作表处理结果:")
             for sheet_result in result['sheet_results']:
@@ -2654,4 +2710,5 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas>=1.0.0
+openpyxl>=3.0.0
+tqdm>=4.45.0
+psutil>=5.7.0
+chardet>=5.0.0
+pymysql>=1.0.0
+xlsxwriter>=3.0.0

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,43 +1,34 @@
-# scripts agent instructions
+# scripts navigation card
 
-## Purpose
+`scripts/` 保存独立 Excel 辅助工具，不属于 `XDB.py` 核心导入路径。
+修改脚本 CLI、`config_template.ini` 或脚本文档前先读本卡片。
+关键文件：`XLSX-split.py`、`XLSX-SheetCutter.py`、`XLSX-SheetMerger.py`、`客户分类切割.py`、`README_XLSX-split.md`。
 
-`scripts/` 保存独立的 Excel 辅助工具：拆分 CSV、按 sheet 切割、合并 sheet，以及客户名称分类。它们服务于数据整理，不是 `XDB.py` 的核心导入路径。
+## Local invariants
 
-## Scope
-
-适用于 `scripts/` 下的 Python 脚本、`config_template.ini` 和脚本文档。
-
-## Read first
-
-- `scripts/README_XLSX-split.md`
-- `scripts/config_template.ini`
-- 修改目标脚本本身的 CLI 参数、输入列和输出文件逻辑。
-- `.github/workflows/multi-platform-build.yaml` 中对应 PyInstaller 构建命令。
+- 保持脚本可从仓库根目录用 `python scripts/<name>.py ...` 运行。
+- `XLSX-split.py` 依赖 `General`、`TagDepartments`、`ColumnMappings`，并读取可选 `DELLIST`；改配置解析时保持 key 兼容。
+- `XLSX-SheetCutter.py`、`XLSX-SheetMerger.py` 当前只复制单元格值，不复制样式；语义变化要同步用法说明。
+- `客户分类切割.py` 要求输入有 `Name` 列；分类关键词/regex 顺序会影响结果。
+- 脚本输出是用户数据产物；smoke 必须写到临时目录。
 
 ## Local rules
 
-- 保持脚本可从仓库根目录直接运行；修改参数时同步脚本文档或用法提示。
-- `XLSX-split.py` 依赖 INI 的 `General`、`TagDepartments`、`ColumnMappings`，可选 `DELLIST`；不要破坏这些 key 名称的兼容性。
-- `XLSX-SheetCutter.py` 和 `XLSX-SheetMerger.py` 当前只复制单元格值，不复制样式；如果改变语义，要在用法说明中写清楚。
-- `客户分类切割.py` 依赖输入表的 `Name` 列，分类规则顺序会影响结果；修改关键词或顺序时用样例数据验证。
-- 输出的 CSV/XLSX 是用户数据产物；测试时写入临时目录。
+- 修改 flag、位置参数、config key、输出文件名或必需输入列时，同步 README/help/config template。
+- 不让辅助脚本依赖 `XDB.py` 私有实现，除非同时说明并验证这个耦合。
+- CI 会打包 `XLSX-split.py`、`XLSX-SheetCutter.py`、`XLSX-SheetMerger.py`；重命名入口必须改 workflow。
 
 ## Do not
 
-- 不把本机真实绝对路径写进脚本默认值；示例路径只放在模板或文档中。
-- 不手动提交脚本生成的 CSV/XLSX 输出文件。
-- 不让辅助脚本反向依赖 `XDB.py` 的内部实现，除非同时补测试说明和打包验证。
+- 不新增本机绝对路径作为默认值；示例路径只放模板或文档。
+- 不提交本地运行生成的 CSV/XLSX。
+- 不静默改变 CSV 输出编码；保持配置驱动。
 
 ## Validation
 
-无法从仓库中确认专用自动测试命令，优先运行根目录通用验证命令。按改动脚本补最小 smoke：
+使用根验证，并按改动脚本补 smoke：
 
 - `python scripts/XLSX-split.py -c <config.ini>`
 - `python scripts/XLSX-SheetCutter.py <input.xlsx>`
 - `python scripts/XLSX-SheetMerger.py <input1.xlsx> <input2.xlsx>`
 - `python scripts/客户分类切割.py <input.xlsx> <output_dir>`
-
-## Notes for future agents
-
-CI 会用 PyInstaller 分别打包 `XLSX-split.py`、`XLSX-SheetCutter.py`、`XLSX-SheetMerger.py`；重命名文件或入口会影响 release 资产。

--- a/scripts/XLSX-SheetCutter.py
+++ b/scripts/XLSX-SheetCutter.py
@@ -11,6 +11,19 @@ def sanitize_filename(filename):
     filename = filename.strip()
     return filename
 
+def unique_output_file(directory, base_name, sheet_name, used_paths):
+    sanitized_sheet_name = sanitize_filename(sheet_name) or "Sheet"
+    base_path = os.path.join(directory, f"{base_name}_{sanitized_sheet_name}.xlsx")
+    output_path = base_path
+    counter = 1
+
+    while output_path in used_paths:
+        output_path = os.path.join(directory, f"{base_name}_{sanitized_sheet_name}_{counter}.xlsx")
+        counter += 1
+
+    used_paths.add(output_path)
+    return output_path
+
 def main():
     # 检查是否提供了输入文件路径
     if len(sys.argv) < 2:
@@ -36,6 +49,7 @@ def main():
         sys.exit(1)
 
     # 遍历所有子表
+    used_output_paths = set()
     for sheet_name in wb.sheetnames:
         ws = wb[sheet_name]
 
@@ -50,10 +64,7 @@ def main():
             new_ws.append(new_row)
 
         # 生成输出文件名，注意处理非法字符
-        sanitized_sheet_name = sanitize_filename(sheet_name)
-        if not sanitized_sheet_name:
-            sanitized_sheet_name = "Sheet"
-        output_file = os.path.join(input_dir, f"{input_name}_{sanitized_sheet_name}.xlsx")
+        output_file = unique_output_file(input_dir, input_name, sheet_name, used_output_paths)
 
         # 保存新的工作簿
         try:
@@ -61,6 +72,10 @@ def main():
             print(f"已保存 {output_file}")
         except Exception as e:
             print(f"保存工作簿时出错 {output_file}: {e}")
+        finally:
+            new_wb.close()
+
+    wb.close()
 
 if __name__ == "__main__":
     main()

--- a/scripts/XLSX-SheetMerger.py
+++ b/scripts/XLSX-SheetMerger.py
@@ -22,7 +22,19 @@ def sanitize_sheet_name(name):
     invalid_chars = '[]:*?/\\'
     for char in invalid_chars:
         name = name.replace(char, '')
-    return name
+    return name.strip() or 'Sheet'
+
+def unique_sheet_name(workbook, base_name):
+    base_name = sanitize_sheet_name(base_name)[:31] or 'Sheet'
+    sheet_name = base_name
+    counter = 1
+
+    while sheet_name in workbook.sheetnames:
+        suffix = f"_{counter}"
+        sheet_name = f"{base_name[:31-len(suffix)]}{suffix}"
+        counter += 1
+
+    return sheet_name
 
 def main():
     # 获取输入文件列表
@@ -83,14 +95,8 @@ def main():
             else:
                 new_sheet_name = f"{file_basename}_{sheet_name}"
 
-            new_sheet_name = sanitize_sheet_name(new_sheet_name)
-
-            # 如果工作表名已存在，添加数字后缀
-            original_sheet_name = new_sheet_name
-            counter = 1
-            while new_sheet_name in output_wb.sheetnames:
-                new_sheet_name = f"{original_sheet_name}_{counter}"
-                counter += 1
+            # 清理、截断并确保工作表名唯一
+            new_sheet_name = unique_sheet_name(output_wb, new_sheet_name)
 
             # 创建新的工作表
             new_ws = output_wb.create_sheet(title=new_sheet_name)
@@ -101,6 +107,8 @@ def main():
                 for cell in row:
                     new_row.append(cell.value)
                 new_ws.append(new_row)
+
+        wb.close()
 
     # 保存合并后的工作簿
     try:

--- a/scripts/XLSX-split.py
+++ b/scripts/XLSX-split.py
@@ -22,13 +22,14 @@ raw_sheet_name = config.get('General', 'raw_sheet_name')
 csv_encoding = config.get('General', 'csv_encoding', fallback='utf-8')
 department_column_name = config.get('General', 'KEY', fallback='二级部门名称')
 del_key = config.get('General', 'DELKEY', fallback='姓名')  # 读取DELKEY
+os.makedirs(output_directory, exist_ok=True)
 
 tag_departments = {}
 for tag, departments in config.items('TagDepartments'):
     tag_departments[tag] = [dep.strip() for dep in departments.split(',')]
 
 # 读取DELLIST的内容
-name_list = config.get('DELLIST', del_key, fallback="").split(", ")
+name_list = [name.strip() for name in config.get('DELLIST', del_key, fallback="").split(",") if name.strip()]
 
 # 读取XLSX文件
 workbook = load_workbook(xlsx_file)
@@ -39,7 +40,11 @@ if raw_sheet_name in workbook.sheetnames:
 
     # 读取表格数据
     data = []
-    columns_to_process = config.get('ColumnMappings', raw_sheet_name, fallback="姓名, 邮箱前缀, 一级部门名称, 二级部门名称").split(",")
+    columns_to_process = [
+        column.strip()
+        for column in config.get('ColumnMappings', raw_sheet_name, fallback="姓名, 邮箱前缀, 一级部门名称, 二级部门名称").split(",")
+        if column.strip()
+    ]
     print("列名称:", columns_to_process)
 
     for row in sheet.iter_rows(min_row=2, values_only=True):
@@ -77,3 +82,5 @@ if raw_sheet_name in workbook.sheetnames:
         print(f"已生成CSV文件: {filepath}")
 else:
     print(f"名为 '{raw_sheet_name}' 的子表不存在。")
+
+workbook.close()

--- a/scripts/客户分类切割.py
+++ b/scripts/客户分类切割.py
@@ -29,6 +29,10 @@ print(f"输出目录: {output_dir}")
 df = pd.read_excel(input_file)
 print(f"总共读取到 {len(df)} 行数据")
 
+if 'Name' not in df.columns:
+    print("错误: 输入文件缺少必需列 Name")
+    sys.exit(1)
+
 # 定义规则
 rules = {
     "教育类客户": {
@@ -98,19 +102,21 @@ if save_in_one_file:
 
 # 创建子表
 for category, rule in rules.items():
+    source_df = unmatched
     # 初始化筛选条件
-    condition = pd.Series(False, index=df.index)
+    condition = pd.Series(False, index=source_df.index)
     
     # 处理关键词匹配
     if "keywords" in rule:
-        condition |= df['Name'].str.contains('|'.join(rule['keywords']), case=False, na=False)
+        keyword_pattern = '|'.join(re.escape(keyword) for keyword in rule['keywords'])
+        condition |= source_df['Name'].str.contains(keyword_pattern, case=False, na=False, regex=True)
     
     # 处理正则表达式匹配
     if "regex" in rule:
-        condition |= df['Name'].str.match(rule['regex'])
+        condition |= source_df['Name'].str.match(rule['regex'], na=False)
     
     # 根据条件提取数据
-    matched = df[condition]
+    matched = source_df[condition]
     
     # 将匹配到的从未匹配中删除
     unmatched = unmatched.loc[~condition]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,37 +1,28 @@
-# tests agent instructions
+# tests navigation card
 
-## Purpose
+`tests/` 保存 XDB 导入正确性的快速回归覆盖。
+修改测试、fixture、CLI subprocess helper 或数据库 fake 前先读本卡片。
+关键文件：`tests/test_xdb_regressions.py` 以及 `XDB.py` 中对应被测代码。
 
-`tests/` 保存 XDB 的回归测试，重点覆盖字段映射、列顺序、类型推断、SQL 标识符清理和数据库写入行为。
+## Local invariants
 
-## Scope
-
-适用于 `tests/` 下的所有测试文件和测试 fixture。
-
-## Read first
-
-- `tests/test_xdb_regressions.py`
-- `XDB.py` 中被测函数或类。
-- `.github/workflows/test.yml` 的 CI 测试步骤。
+- 使用标准库 `unittest`；保持 `python -m unittest discover -s tests -p 'test_*.py'` 可发现。
+- CLI 测试用 `sys.executable` 调仓库根目录 `XDB.py`；不要依赖 shell alias、已安装包或偶然 cwd。
+- 临时 CSV/XLSX/SQLite 文件放在 `tempfile.TemporaryDirectory()` 或等价可丢弃位置。
+- MySQL 单元行为优先用 fake connection/cursor；真实 MySQL 默认交给 CI smoke，除非用户要求 live 验证。
 
 ## Local rules
 
-- 使用标准库 `unittest` 风格，保持 `python -m unittest discover -s tests -p 'test_*.py'` 可发现。
-- 需要调用 CLI 时使用 `sys.executable` 和仓库根目录的 `XDB.py`，避免依赖 shell alias 或当前目录偶然状态。
-- 测试文件、SQLite 数据库和输出结果必须放在 `tempfile.TemporaryDirectory()` 或等价临时位置。
-- 单元级 MySQL 行为优先用 fake connection/cursor；需要真实 MySQL 时对齐 CI 的测试服务参数。
-- 修复 mapping、chunk、append/overwrite、SQL 安全或 CSV/Excel 解析问题时，添加能失败再通过的回归测试。
+- 修复 mapping、chunk、append/overwrite、SQL identifier、CSV parsing、Excel merged-cell 或 rollback 时，补一个修复前会失败的回归测试。
+- 保留 subprocess stdout/stderr capture，让 CLI 失败可诊断。
+- 测试不得依赖执行顺序、用户数据库、本机绝对路径或仓库外样本。
 
 ## Do not
 
-- 不让测试依赖执行顺序、用户本机数据库、固定绝对路径或仓库外部样本文件。
-- 不在测试中写入持久 `.db`、`.xlsx`、`.csv` 或日志文件到仓库根目录。
-- 不吞掉子进程 stderr/stdout；CLI 失败时要能看见诊断信息。
+- 不从测试向仓库根目录写持久 `.db`、`.xlsx`、`.csv` 或日志。
+- 不因为场景难搭就跳过断言；用小型合成 fixture。
+- 不把测试目录改成 `pytest`，除非仓库新增依赖并更新 CI。
 
 ## Validation
 
 - `python -m unittest discover -s tests -p 'test_*.py'`
-
-## Notes for future agents
-
-当前测试目录在 CI 中先于完整 CSV/Excel/MySQL smoke 执行；这里适合放快速、可本地运行的回归用例。

--- a/tests/test_xdb_regressions.py
+++ b/tests/test_xdb_regressions.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from openpyxl import Workbook
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 XDB_SCRIPT = REPO_ROOT / "XDB.py"
 
@@ -102,6 +104,41 @@ class XDBRegressionTests(unittest.TestCase):
         self.assertEqual(XDB.sanitize_column_name("updated_at"), "updated_at")
         self.assertEqual(XDB.sanitize_column_name("delete_flag"), "delete_flag")
         self.assertEqual(XDB.sanitize_column_name("select_code"), "select_code")
+
+    def test_generated_pk_avoids_case_insensitive_id_collision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            xlsx_path = tmp_path / "sample.xlsx"
+            db_path = tmp_path / "sample.db"
+
+            wb = Workbook()
+            ws = wb.active
+            ws.title = "Data"
+            ws.append(["ID", "Name"])
+            ws.append([1, "Alice"])
+            wb.save(xlsx_path)
+            wb.close()
+
+            run_xdb(
+                str(xlsx_path),
+                "--db-type",
+                "sqlite",
+                "--sqlite-path",
+                str(db_path),
+                "--target-table",
+                "sample",
+                "--mode",
+                "overwrite",
+                "--quiet",
+            )
+
+            with sqlite3.connect(db_path) as conn:
+                table_info = conn.execute("PRAGMA table_info(sample)").fetchall()
+                rows = conn.execute("SELECT xdb_id, ID, Name FROM sample").fetchall()
+
+            columns = [row[1] for row in table_info]
+            self.assertEqual(columns[:3], ["xdb_id", "ID", "Name"])
+            self.assertEqual(rows, [(1, 1, "Alice")])
 
     def test_mysql_mapping_write_uses_source_column_order(self):
         XDB = import_xdb()

--- a/tests/test_xdb_regressions.py
+++ b/tests/test_xdb_regressions.py
@@ -1,0 +1,161 @@
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+XDB_SCRIPT = REPO_ROOT / "XDB.py"
+
+
+def import_xdb():
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        import XDB
+    finally:
+        sys.path.pop(0)
+    return XDB
+
+
+def run_xdb(*args):
+    return subprocess.run(
+        [sys.executable, str(XDB_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+class XDBRegressionTests(unittest.TestCase):
+    def test_sqlite_mapping_preserves_all_rows_across_chunks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            csv_path = tmp_path / "sample.csv"
+            db_path = tmp_path / "mapped.db"
+            csv_path.write_text("A,B\n1,x\n2,y\n3,z\n", encoding="utf-8")
+
+            run_xdb(
+                str(csv_path),
+                "--db-type",
+                "sqlite",
+                "--sqlite-path",
+                str(db_path),
+                "--target-table",
+                "mapped",
+                "--mode",
+                "overwrite",
+                "--workers",
+                "1",
+                "--chunk-size",
+                "2",
+                "--mapping",
+                "Sheet1:A=aa,B=bb",
+                "--quiet",
+            )
+
+            with sqlite3.connect(db_path) as conn:
+                rows = conn.execute("SELECT aa, bb FROM mapped ORDER BY aa").fetchall()
+
+            self.assertEqual(rows, [(1, "x"), (2, "y"), (3, "z")])
+
+    def test_mapping_order_does_not_swap_column_types(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            csv_path = tmp_path / "sample.csv"
+            db_path = tmp_path / "mapped.db"
+            csv_path.write_text("A,B\n1,x\n2,y\n3,z\n", encoding="utf-8")
+
+            run_xdb(
+                str(csv_path),
+                "--db-type",
+                "sqlite",
+                "--sqlite-path",
+                str(db_path),
+                "--target-table",
+                "mapped",
+                "--mode",
+                "overwrite",
+                "--workers",
+                "1",
+                "--chunk-size",
+                "10",
+                "--mapping",
+                "Sheet1:B=bb,A=aa",
+                "--quiet",
+            )
+
+            with sqlite3.connect(db_path) as conn:
+                table_info = conn.execute("PRAGMA table_info(mapped)").fetchall()
+                rows = conn.execute("SELECT aa, bb FROM mapped ORDER BY aa").fetchall()
+
+            types_by_name = {row[1]: row[2] for row in table_info}
+            self.assertEqual(types_by_name["aa"], "INTEGER")
+            self.assertEqual(types_by_name["bb"], "TEXT")
+            self.assertEqual(rows, [(1, "x"), (2, "y"), (3, "z")])
+
+    def test_identifier_sanitizer_keeps_common_audit_columns(self):
+        XDB = import_xdb()
+
+        self.assertEqual(XDB.sanitize_column_name("created_at"), "created_at")
+        self.assertEqual(XDB.sanitize_column_name("updated_at"), "updated_at")
+        self.assertEqual(XDB.sanitize_column_name("delete_flag"), "delete_flag")
+        self.assertEqual(XDB.sanitize_column_name("select_code"), "select_code")
+
+    def test_mysql_mapping_write_uses_source_column_order(self):
+        XDB = import_xdb()
+
+        class FakeCursor:
+            def __init__(self):
+                self.executemany_calls = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def executemany(self, sql, rows):
+                self.executemany_calls.append((sql, list(rows)))
+
+            def execute(self, *args, **kwargs):
+                return None
+
+        class FakeConnection:
+            def __init__(self):
+                self.cursor_obj = FakeCursor()
+                self.commits = 0
+
+            def cursor(self):
+                return self.cursor_obj
+
+            def commit(self):
+                self.commits += 1
+
+            def rollback(self):
+                pass
+
+            def close(self):
+                pass
+
+        fake_conn = FakeConnection()
+        db = XDB.MySQLDatabase("localhost", 3306, "root", "pass", "testdb")
+        db.conn = fake_conn
+
+        inserted = db.write_data(
+            "mapped",
+            ["A", "B"],
+            [[(1, "x"), (2, "y"), (3, "z")]],
+            {"B": "bb", "A": "aa"},
+        )
+
+        self.assertEqual(inserted, 3)
+        self.assertEqual(fake_conn.commits, 1)
+        sql, rows = fake_conn.cursor_obj.executemany_calls[0]
+        self.assertIn("`aa`, `bb`", " ".join(sql.split()))
+        self.assertEqual(rows, [(1, "x"), (2, "y"), (3, "z")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix XDB import edge cases around safe primary keys, raw-header mapping, CSV quote handling, merged-cell propagation, mapped write order, and rollback-safe chunk writes.
- Add `requirements.txt`, regression coverage, and CI execution of the unittest regression suite.
- Tighten standalone XLSX helper scripts for output collisions, workbook cleanup, config parsing, and customer classification matching.
- Rebuild the repository `AGENTS.md` hierarchy as a root router plus scoped navigation cards for `scripts/`, `tests/`, and `.github/`.
- Fix CI-discovered SQLite column collision when a source workbook contains `ID` and the generated primary key would otherwise be `id`.

## Validation

- `python -m py_compile XDB.py scripts/*.py`
- `python -m unittest discover -s tests -p 'test_*.py'`
- CSV-to-SQLite CLI smoke with explicit `--csv-separator '|'`, `--csv-quotechar "'"`, chunk size 1, and field mapping
- Excel-to-SQLite CLI smoke with raw-header field mapping
- Excel-to-SQLite smoke for source `ID` column plus generated `xdb_id` primary key
- Script smoke for `XLSX-split.py`, `XLSX-SheetCutter.py`, `XLSX-SheetMerger.py`, and `客户分类切割.py`
